### PR TITLE
Remove whatsapp client import

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,5 +3,4 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import './lib/i18n';
-import '@/services/whatsapp/whatsapp.client';
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- remove whatsapp client import from the React entrypoint

## Testing
- `bun install` *(fails: 403 network error)*
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6852153f1b8883309cdbc852bdbec2c6