### PR TITLE
Add global loading spinner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "@/context/AuthContext";
 import { AuthLayout } from "@/layouts/AuthLayout";
+import LoadingOverlay from "@/components/LoadingOverlay";
+import RouteChangeListener from "@/components/RouteChangeListener";
 import Layout from "./components/layout/Layout";
 import Landing from "./pages/Landing";
 import Login from "./pages/Login";
@@ -27,8 +29,10 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <LoadingOverlay />
       <AuthProvider>
         <BrowserRouter>
+          <RouteChangeListener />
           <Routes>
             {/* Public Routes */}
             <Route path="/" element={<Landing />} />

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useLoadingStore } from '@/stores/useLoadingStore';
+import Spinner from '@/components/ui/spinner';
+
+const LoadingOverlay: React.FC = () => {
+  const isLoading = useLoadingStore((state) => state.isLoading);
+
+  if (!isLoading) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/70 dark:bg-black/70">
+      <Spinner size="h-12 w-12" />
+    </div>
+  );
+};
+
+export default LoadingOverlay;

--- a/src/components/RouteChangeListener.tsx
+++ b/src/components/RouteChangeListener.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useLoadingStore } from '@/stores/useLoadingStore';
+
+const RouteChangeListener = () => {
+  const location = useLocation();
+  const hideLoading = useLoadingStore((state) => state.hideLoading);
+
+  useEffect(() => {
+    hideLoading();
+  }, [location, hideLoading]);
+
+  return null;
+};
+
+export default RouteChangeListener;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { motion, Variants } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
 import { useAppStore } from '@/stores/useAppStore';
+import { useLoadingStore } from '@/stores/useLoadingStore';
 import { cn } from '@/lib/utils';
 import {
   LayoutDashboard, Calendar, Activity, Users, Shield, BarChart3,
@@ -14,6 +15,7 @@ import AppLogo from '@/components/ui/AppLogo';
 const Sidebar = () => {
   const { t } = useTranslation();
   const { sidebarOpen, setSidebarOpen, language } = useAppStore();
+  const showLoading = useLoadingStore((state) => state.showLoading);
 
   const menuItems = [
     { icon: LayoutDashboard, label: t('dashboard'), href: '/' },
@@ -78,6 +80,7 @@ const Sidebar = () => {
                 <div key={item.href}>
                   <NavLink
                     to={item.href}
+                    onClick={showLoading}
                     className={({ isActive }) =>
                       cn(
                         'flex items-center gap-3 px-4 py-2 rounded-lg font-medium transition-colors',
@@ -95,6 +98,7 @@ const Sidebar = () => {
                         <NavLink
                           key={sub.href}
                           to={sub.href}
+                          onClick={showLoading}
                           className={({ isActive }) =>
                             cn(
                               'flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors',

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface SpinnerProps {
+  size?: string;
+  className?: string;
+}
+
+export const Spinner: React.FC<SpinnerProps> = ({ size = 'h-8 w-8', className = '' }) => (
+  <div
+    className={`animate-spin rounded-full border-4 border-blue-600 border-t-transparent ${size} ${className}`}
+  />
+);
+
+export default Spinner;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Eye, EyeOff, ArrowRight } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
+import { useLoadingStore } from '@/stores/useLoadingStore';
 
 export default function Login() {
   const [loginCredentials, setLoginCredentials] = useState({
@@ -24,6 +25,9 @@ export default function Login() {
   });
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+
+  const showLoading = useLoadingStore((state) => state.showLoading);
+  const hideLoading = useLoadingStore((state) => state.hideLoading);
   
   const navigate = useNavigate();
   const location = useLocation();
@@ -51,6 +55,7 @@ export default function Login() {
     }
 
     setIsLoading(true);
+    showLoading();
     
     try {
       const result = await login(loginCredentials.email, loginCredentials.password);
@@ -76,6 +81,7 @@ export default function Login() {
       });
     } finally {
       setIsLoading(false);
+      hideLoading();
     }
   };
 
@@ -92,6 +98,7 @@ export default function Login() {
     }
 
     setIsLoading(true);
+    showLoading();
     
     try {
       const redirectUrl = `${window.location.origin}/`;
@@ -128,6 +135,7 @@ export default function Login() {
       });
     } finally {
       setIsLoading(false);
+      hideLoading();
     }
   };
 

--- a/src/stores/useLoadingStore.ts
+++ b/src/stores/useLoadingStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface LoadingState {
+  isLoading: boolean;
+  showLoading: () => void;
+  hideLoading: () => void;
+}
+
+export const useLoadingStore = create<LoadingState>((set) => ({
+  isLoading: false,
+  showLoading: () => set({ isLoading: true }),
+  hideLoading: () => set({ isLoading: false }),
+}));


### PR DESCRIPTION
## Summary
- add Spinner and global overlay components
- introduce zustand store for loading state
- show/hide loading during login and navigation
- hide loader on route changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852f6efa7548330b215c5434ded78aa