### PR TITLE
Fix auth form toggling

### DIFF
--- a/src/components/auth/AuthForms.tsx
+++ b/src/components/auth/AuthForms.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import LoginForm from './LoginForm';
+import RegisterForm from './RegisterForm';
+
+interface AuthFormsProps {
+  mode: 'login' | 'register';
+  setMode: (mode: 'login' | 'register') => void;
+  onClose?: () => void;
+}
+
+const AuthForms: React.FC<AuthFormsProps> = ({ mode, setMode, onClose }) => {
+  return mode === 'login' ? (
+    <LoginForm onClose={onClose} onSwitchToRegister={() => setMode('register')} />
+  ) : (
+    <RegisterForm onClose={onClose} onSwitchToLogin={() => setMode('login')} />
+  );
+};
+
+export default AuthForms;
+

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAppStore } from '@/stores/useAppStore';
 import { X } from 'lucide-react';
-import LoginForm from './LoginForm';
-import RegisterForm from './RegisterForm';
+import { useAuth } from '@/context/AuthContext';
+import AuthForms from './AuthForms';
 
 const AuthModal = () => {
   const { showAuthModal, setShowAuthModal } = useAppStore();
+  const { isAuthenticated } = useAuth();
   const [mode, setMode] = useState<'login' | 'register'>('login');
 
   const modalVariants = {
@@ -25,7 +26,7 @@ const AuthModal = () => {
     }
   };
 
-  if (!showAuthModal) return null;
+  if (!showAuthModal || isAuthenticated) return null;
 
   return (
     <AnimatePresence>
@@ -56,17 +57,11 @@ const AuthModal = () => {
 
           {/* Form */}
           <div className="p-8">
-            {mode === 'login' ? (
-              <LoginForm
-                onClose={() => setShowAuthModal(false)}
-                onSwitchToRegister={() => setMode('register')}
-              />
-            ) : (
-              <RegisterForm
-                onClose={() => setShowAuthModal(false)}
-                onSwitchToLogin={() => setMode('login')}
-              />
-            )}
+            <AuthForms
+              mode={mode}
+              setMode={setMode}
+              onClose={() => setShowAuthModal(false)}
+            />
           </div>
         </motion.div>
       </div>

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -68,6 +68,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onClose, onSwitchToLogin })
           title: 'تم إنشاء الحساب بنجاح',
           description: 'يرجى التحقق من بريدك الإلكتروني لتفعيل الحساب',
         });
+        onSwitchToLogin && onSwitchToLogin();
         onClose && onClose();
       }
     } catch (error) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,10 +1,19 @@
-import React from 'react';
-import LoginForm from '@/components/auth/LoginForm';
+import React, { useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import AuthForms from '@/components/auth/AuthForms';
+import { useAuth } from '@/context/AuthContext';
 
 export default function Login() {
+  const { isAuthenticated } = useAuth();
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-white to-purple-50 p-4">
-      <LoginForm />
+      <AuthForms mode={mode} setMode={setMode} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `AuthForms` component to handle login/register toggle
- refactor `AuthModal` to use `AuthForms`
- redirect away from auth when already logged in
- show login form again after successful registration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530a63b5808330a942ecdb5da24012