### PR TITLE
Unify Tailwind color palette

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -103,7 +103,7 @@ export function AppHeader() {
                   variant="outline"
                   size="sm"
                   onClick={action.action}
-                  className="bg-gradient-to-r from-blue-500 to-purple-600 text-white border-0 hover:from-blue-600 hover:to-purple-700 transition-all duration-300 shadow-md hover:shadow-lg"
+                  className="bg-gradient-to-r from-primary to-accent text-white border-0 hover:from-primary/80 hover:to-accent/80 transition-all duration-300 shadow-md hover:shadow-lg"
                 >
                   <action.icon className={`h-4 w-4 ${isRTL ? 'ml-1' : 'mr-1'}`} />
                   {action.title}
@@ -171,8 +171,8 @@ export function AppHeader() {
             {/* User menu */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="flex items-center space-x-2 space-x-reverse hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl p-2">
-                  <div className="w-8 h-8 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
+                <Button variant="ghost" className="flex items-center space-x-2 space-x-reverse hover:bg-background-desktop rounded-xl p-2">
+                  <div className="w-8 h-8 bg-gradient-to-r from-primary to-accent rounded-full flex items-center justify-center">
                     <User className="h-4 w-4 text-white" />
                   </div>
                   <div className="hidden md:block text-right">

--- a/src/components/layout/ContextCard.tsx
+++ b/src/components/layout/ContextCard.tsx
@@ -125,8 +125,8 @@ const ContextCard = () => {
       } w-80 bg-white/90 dark:bg-gray-800/90 backdrop-blur-xl rounded-2xl shadow-2xl border border-gray-200/50 dark:border-gray-700/50 p-6 z-20 transition-all duration-300`}
     >
       <div className="flex items-center gap-3 mb-4">
-        <div className="p-3 bg-gradient-to-br from-blue-500/20 to-purple-500/20 rounded-xl">
-          <Icon className="w-6 h-6 text-blue-600 dark:text-blue-400" />
+        <div className="p-3 bg-gradient-to-br from-primary/20 to-accent/20 rounded-xl">
+          <Icon className="w-6 h-6 text-primary" />
         </div>
         <div>
           <h3 className="font-semibold text-gray-900 dark:text-white">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -85,8 +85,8 @@ const Sidebar = () => {
                     className={({ isActive }) =>
                       cn(
                         'flex items-center gap-3 px-4 py-2 rounded-lg font-medium transition-colors',
-                        'text-gray-700 dark:text-gray-300 hover:bg-blue-100 dark:hover:bg-gray-800',
-                        isActive && 'bg-blue-100 dark:bg-gray-800 text-blue-600 dark:text-blue-300'
+                        'text-muted hover:bg-primary/5',
+                        isActive && 'bg-primary/10 text-primary'
                       )
                     }
                   >
@@ -103,8 +103,8 @@ const Sidebar = () => {
                           className={({ isActive }) =>
                             cn(
                               'flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors',
-                              'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800',
-                              isActive && 'bg-blue-50 dark:bg-gray-700 text-blue-700 dark:text-blue-300'
+                              'text-muted hover:bg-primary/5',
+                              isActive && 'bg-primary/10 text-primary'
                             )
                           }
                         >

--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,20 @@
 /* CSS Custom Properties for theming */
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Unified color palette */
+    --primary-color: 221 83% 53%;
+    --primary-color-foreground: 0 0% 100%;
+    --secondary-color: 15 86% 59%;
+    --secondary-color-foreground: 0 0% 100%;
+    --accent-color: 171 66% 44%;
+    --accent-foreground-color: 0 0% 100%;
+    --background-color: 0 0% 100%;
+    --background-color-desktop: 0 0% 98%;
+    --text-color: 222.2 47.4% 11.2%;
+
+    /* Existing tokens mapped to the new palette */
+    --background: var(--background-color);
+    --foreground: var(--text-color);
 
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
@@ -15,17 +27,17 @@
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: var(--primary-color);
+    --primary-foreground: var(--primary-color-foreground);
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: var(--secondary-color);
+    --secondary-foreground: var(--secondary-color-foreground);
 
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: var(--accent-color);
+    --accent-foreground: var(--accent-foreground-color);
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
@@ -53,8 +65,13 @@
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background-color: 222.2 84% 4.9%;
+    --background-color-desktop: 217.2 32.6% 17.5%;
+    --text-color: 210 40% 98%;
+
+    /* Map existing tokens */
+    --background: var(--background-color);
+    --foreground: var(--text-color);
 
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
@@ -62,17 +79,17 @@
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: var(--primary-color);
+    --primary-foreground: var(--primary-color-foreground);
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: var(--secondary-color);
+    --secondary-foreground: var(--secondary-color-foreground);
 
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: var(--accent-color);
+    --accent-foreground: var(--accent-foreground-color);
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
@@ -109,7 +126,7 @@
   }
 
   body {
-    @apply bg-background text-foreground antialiased;
+    @apply bg-background text-foreground antialiased lg:bg-[hsl(var(--background-color-desktop))];
     font-feature-settings: "rlig" 1, "calt" 1;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   }
@@ -198,16 +215,16 @@
   }
 
   .text-accent {
-    @apply text-blue-600 dark:text-blue-400;
+    @apply text-[hsl(var(--accent-color))] dark:text-[hsl(var(--accent-color))];
   }
 
   /* Button variants */
   .btn-primary {
-    @apply bg-gradient-to-r from-blue-600 to-blue-500 hover:from-blue-700 hover:to-blue-600 text-white font-medium px-4 py-2 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md;
+    @apply bg-primary text-primary-foreground font-medium px-4 py-2 rounded-lg transition-all duration-200 hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-primary;
   }
 
   .btn-secondary {
-    @apply bg-gradient-to-r from-gray-600 to-gray-500 hover:from-gray-700 hover:to-gray-600 text-white font-medium px-4 py-2 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md;
+    @apply bg-secondary text-secondary-foreground font-medium px-4 py-2 rounded-lg transition-all duration-200 hover:bg-secondary/90 focus-visible:ring-2 focus-visible:ring-secondary;
   }
 
   /* Navigation styles */
@@ -216,7 +233,7 @@
   }
 
   .nav-link-active {
-    @apply bg-gradient-to-r from-blue-500/10 to-blue-600/10 text-blue-600 dark:text-blue-500 shadow-lg shadow-blue-500/20;
+    @apply bg-primary/10 text-primary shadow-lg shadow-primary/20;
   }
 
   .nav-link-inactive {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,20 +18,22 @@ export default {
 			}
 		},
 		extend: {
-			colors: {
-				border: 'hsl(var(--border))',
-				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))'
-				},
-				secondary: {
-					DEFAULT: 'hsl(var(--secondary))',
-					foreground: 'hsl(var(--secondary-foreground))'
-				},
+                        colors: {
+                                border: 'hsl(var(--border))',
+                                input: 'hsl(var(--input))',
+                                ring: 'hsl(var(--ring))',
+                                background: 'hsl(var(--background))',
+                                'background-desktop': 'hsl(var(--background-color-desktop))',
+                                foreground: 'hsl(var(--foreground))',
+                                text: 'hsl(var(--text-color))',
+                                primary: {
+                                        DEFAULT: 'hsl(var(--primary))',
+                                        foreground: 'hsl(var(--primary-foreground))'
+                                },
+                                secondary: {
+                                        DEFAULT: 'hsl(var(--secondary))',
+                                        foreground: 'hsl(var(--secondary-foreground))'
+                                },
 				destructive: {
 					DEFAULT: 'hsl(var(--destructive))',
 					foreground: 'hsl(var(--destructive-foreground))'


### PR DESCRIPTION
## Summary
- centralize Tailwind color variables
- add responsive background token
- use palette colors in Sidebar, ContextCard and AppHeader
- update button and navigation styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because dependencies aren't installed)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685341c14a588330b3e6a2006e4378fd