### PR TITLE
Improve theme colors and gradient styles

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -59,7 +59,8 @@ const Hero = ({ onLoginClick }: HeroProps) => {
             <Button
               onClick={onLoginClick}
               size="lg"
-              className="bg-gradient-to-r from-yellow-500 to-orange-500 hover:from-yellow-600 hover:to-orange-600 text-white text-lg px-8 py-6 shadow-2xl hover:shadow-yellow-500/25 transition-all duration-300 transform hover:scale-105"
+              variant="gradient"
+              className="text-lg px-8 py-6 shadow-2xl hover:shadow-primary/25 transition-all duration-300 transform hover:scale-105"
             >
               <ArrowRight className="ml-2 h-6 w-6" />
               ابدأ الآن - مجاناً

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,6 +18,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        gradient: "bg-gradient-primary text-white",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -7,15 +9,15 @@
 @layer base {
   :root {
     /* Unified color palette */
-    --primary-color: 221 83% 53%;
+    --primary-color: 224.3 76.3% 48%;
     --primary-color-foreground: 0 0% 100%;
-    --secondary-color: 15 86% 59%;
+    --secondary-color: 271.5 81.3% 56%;
     --secondary-color-foreground: 0 0% 100%;
-    --accent-color: 171 66% 44%;
+    --accent-color: 160.1 84% 39.4%;
     --accent-foreground-color: 0 0% 100%;
-    --background-color: 0 0% 100%;
-    --background-color-desktop: 0 0% 98%;
-    --text-color: 222.2 47.4% 11.2%;
+    --background-color: 210 20% 98%;
+    --background-color-desktop: 210 20% 98%;
+    --text-color: 215 28% 17%;
 
     /* Existing tokens mapped to the new palette */
     --background: var(--background-color);
@@ -65,9 +67,9 @@
   }
 
   .dark {
-    --background-color: 222.2 84% 4.9%;
-    --background-color-desktop: 217.2 32.6% 17.5%;
-    --text-color: 210 40% 98%;
+    --background-color: 221 39% 11%;
+    --background-color-desktop: 215 28% 17%;
+    --text-color: 210 20% 98%;
 
     /* Map existing tokens */
     --background: var(--background-color);
@@ -128,13 +130,13 @@
   body {
     @apply bg-background text-foreground antialiased lg:bg-[hsl(var(--background-color-desktop))];
     font-feature-settings: "rlig" 1, "calt" 1;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   }
 
   /* Headings */
   h1, h2, h3, h4, h5, h6 {
     @apply font-semibold text-foreground;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   }
 
   h1 {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,8 +17,25 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
+                extend: {
+                        fontFamily: {
+                                sans: ["Inter", "ui-sans-serif", "system-ui"],
+                        },
                         colors: {
+                            brand: {
+                                        primary: "#1D4ED8",
+                                        "primary-dark": "#2563EB",
+                                        secondary: "#9333EA",
+                                        accent: "#10B981",
+                                        background: {
+                                                light: "#F9FAFB",
+                                                dark: "#111827",
+                                        },
+                                        text: {
+                                                light: "#1F2937",
+                                                dark: "#F9FAFB",
+                                        },
+                                },
                                 border: 'hsl(var(--border))',
                                 input: 'hsl(var(--input))',
                                 ring: 'hsl(var(--ring))',
@@ -54,18 +71,21 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
+                                sidebar: {
+                                        DEFAULT: 'hsl(var(--sidebar-background))',
+                                        foreground: 'hsl(var(--sidebar-foreground))',
+                                        primary: 'hsl(var(--sidebar-primary))',
 					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
 					accent: 'hsl(var(--sidebar-accent))',
 					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
 					border: 'hsl(var(--sidebar-border))',
 					ring: 'hsl(var(--sidebar-ring))'
-				}
-			},
-			borderRadius: {
+                                }
+                        },
+                        backgroundImage: {
+                                'gradient-primary': 'linear-gradient(to right, #1D4ED8, #9333EA)',
+                        },
+                        borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',
 				sm: 'calc(var(--radius) - 4px)'


### PR DESCRIPTION
## Summary
- import Inter font and tune global color variables
- define brand palette and gradient in Tailwind config
- add gradient button variant
- update hero CTA button to use gradient

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534c4a86308330a53389f44300761a