### PR TITLE
fix Node module error

### DIFF
--- a/scripts/whatsapp-telegram-bot.js
+++ b/scripts/whatsapp-telegram-bot.js
@@ -1,9 +1,11 @@
-require('dotenv').config();
-const { Client, LocalAuth } = require('whatsapp-web.js');
-const TelegramBot = require('node-telegram-bot-api');
-const qrcode = require('qrcode');
-const fs = require('fs');
-const path = require('path');
+import dotenv from 'dotenv';
+import { Client, LocalAuth } from 'whatsapp-web.js';
+import TelegramBot from 'node-telegram-bot-api';
+import * as qrcode from 'qrcode';
+import fs from 'fs';
+import path from 'path';
+
+dotenv.config();
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;


### PR DESCRIPTION
## Summary
- switch WhatsApp bot script to ESM imports so it works with `type: module`

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68535cf1e83883308957bd0d44f2b629