### PR TITLE
Fix Node ESM issue

### DIFF
--- a/scripts/db.js
+++ b/scripts/db.js
@@ -1,5 +1,5 @@
-const mysql = require('mysql2/promise');
-const fs = require('fs');
+import mysql from 'mysql2/promise';
+import fs from 'fs';
 
 // Read database URL from environment variables
 const DATABASE_URL = process.env.DATABASE_URL || '';


### PR DESCRIPTION
## Summary
- convert DB helper to use ESM imports

## Testing
- `node scripts/db.js --help` *(fails: Cannot find module 'mysql2')*
- `yarn lint` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685368d311e883309380c79bced69523