### PR TITLE
Fix whatsapp-web.js import for ESM

### DIFF
--- a/scripts/whatsapp-telegram-bot.js
+++ b/scripts/whatsapp-telegram-bot.js
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
-import { Client, LocalAuth } from 'whatsapp-web.js';
+import whatsapp from 'whatsapp-web.js';
+const { Client, LocalAuth } = whatsapp;
 import TelegramBot from 'node-telegram-bot-api';
 import * as qrcode from 'qrcode';
 import fs from 'fs';


### PR DESCRIPTION
## Summary
- use default import from whatsapp-web.js in bot script

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `node scripts/whatsapp-telegram-bot.js` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68537a1d149c8330bfcf359c3d88406f