### PR TITLE
Fix WA bot destroy null browser

### DIFF
--- a/scripts/whatsapp-telegram-bot.js
+++ b/scripts/whatsapp-telegram-bot.js
@@ -112,10 +112,21 @@ telegramBot.on('message', async (msg) => {
   } else if (text === '/reset') {
     telegramBot.sendMessage(TELEGRAM_CHAT_ID, '🗑️ جارٍ إعادة تعيين الجلسة...');
     clearSession();
-    whatsappClient.destroy().then(() => {
-      console.log('تم إنهاء جلسة واتساب القديمة.');
+    if (whatsappClient && whatsappClient.pupBrowser) {
+      whatsappClient
+        .destroy()
+        .then(() => {
+          console.log('تم إنهاء جلسة واتساب القديمة.');
+        })
+        .catch((err) => {
+          console.error('خطأ أثناء إنهاء جلسة واتساب:', err);
+        })
+        .finally(() => {
+          initWhatsApp();
+        });
+    } else {
       initWhatsApp();
-    });
+    }
   } else {
     telegramBot.sendMessage(
       TELEGRAM_CHAT_ID,


### PR DESCRIPTION
## Summary
- handle missing browser instance on /reset to avoid crash

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68537af5ad9483309f56bd8836be31e4