### PR TITLE
Improve responsive sidebar layout

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,6 +18,17 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   const isRTL = language === 'ar';
 
+  const marginClasses = cn(
+    'transition-all duration-200 ease-in-out',
+    sidebarOpen
+      ? isRTL
+        ? '2xl:mr-72'
+        : '2xl:ml-72'
+      : isRTL
+        ? 'lg:mr-16 2xl:mr-16'
+        : 'lg:ml-16 2xl:ml-16'
+  );
+
   return (
     <div
       className={cn(
@@ -32,15 +43,14 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <div
         className={cn(
           'flex flex-col flex-1 min-h-screen transition-all duration-200 ease-in-out',
-          sidebarOpen ? '2xl:ml-sidebar-full' : '2xl:ml-sidebar-mini',
-          isRTL && (sidebarOpen ? '2xl:ml-0 2xl:mr-sidebar-full' : '2xl:ml-0 2xl:mr-sidebar-mini')
+          marginClasses
         )}
       >
         {/* Topbar */}
-        <Topbar />
+        <Topbar className={marginClasses} />
         
         {/* Page Content */}
-        <main className="flex-1 overflow-auto bg-gradient-to-br from-background to-muted/20">
+        <main className={cn('flex-1 overflow-auto bg-gradient-to-br from-background to-muted/20', marginClasses)}>
           <div className="container mx-auto p-6 max-w-7xl">
             {children}
           </div>

--- a/src/components/layout/SidebarRail.tsx
+++ b/src/components/layout/SidebarRail.tsx
@@ -32,7 +32,7 @@ export const SidebarRail: React.FC = () => {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm xl:hidden"
+          className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm block lg:hidden transition-all duration-200 ease-in-out"
           onClick={() => setSidebarOpen(false)}
         />
       )}
@@ -46,8 +46,9 @@ export const SidebarRail: React.FC = () => {
           'transition-all duration-200 ease-in-out',
           isRTL ? 'right-0 border-l' : 'left-0 border-r',
           sidebarOpen ? 'w-sidebar-full' : 'w-sidebar-mini',
-          'xl:translate-x-0',
-          sidebarOpen ? '' : isRTL ? 'translate-x-full xl:translate-x-0' : '-translate-x-full xl:translate-x-0',
+          'lg:translate-x-0',
+          sidebarOpen ? '' : isRTL ? 'translate-x-full lg:translate-x-0' : '-translate-x-full lg:translate-x-0',
+          'hidden lg:flex',
           '2xl:w-sidebar-full'
         )}
         role="navigation"

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -18,7 +18,11 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useToast } from '@/hooks/use-toast';
 
-const Topbar = () => {
+interface TopbarProps {
+  className?: string;
+}
+
+const Topbar: React.FC<TopbarProps> = ({ className }) => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -62,7 +66,10 @@ const Topbar = () => {
 
   return (
     <motion.header
-      className="sticky top-0 z-30 w-full border-b shadow-sm border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+      className={cn(
+        'sticky top-0 z-30 w-full border-b shadow-sm border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
+        className
+      )}
       initial={{ y: -100 }}
       animate={{ y: 0 }}
       transition={{ type: "spring", stiffness: 300, damping: 30 }}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,7 +19,7 @@ export default {
 		},
                 extend: {
                         width: {
-                                'sidebar-mini': '5rem',
+                                'sidebar-mini': '4rem',
                                 'sidebar-full': '18rem',
                                 'spinner-xs': '1rem',
                                 'spinner-sm': '1.5rem',


### PR DESCRIPTION
## Summary
- use 4rem mini sidebar width
- update Layout margins and transitions for all breakpoints
- update Topbar to accept custom margin classes
- refine SidebarRail breakpoints and overlay logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855eb64ec508330b7f76e22a97d8c77