### PR TITLE
Implement responsive sidebar

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,15 +4,26 @@
 
 | Range | Sidebar Behaviour |
 |-------|------------------|
-| `< xl` | Sidebar overlays full screen when open, hidden when closed. |
-| `xl – 2xl` | Sidebar shown as mini rail (`w-sidebar-mini`). Labels appear in tooltips. |
-| `≥ 2xl` | Sidebar expanded to `w-sidebar-full`. |
+| `< lg` | Hidden by default. Toggle shows full-screen overlay. |
+| `lg – xl` | Mini rail (`w-16`) collapsed. Toggle expands to `w-72`. |
+| `≥ 2xl` | Expanded by default (`w-72`). Toggle collapses to `w-16`. |
 
 RTL layouts mirror these positions.
+
+```
+           < lg      lg–xl     ≥2xl
+LTR  | [  overlay ] [ mini ] [ full ]
+RTL  | [ overlay ] [ mini ] [ full ]
+```
 
 ## Spacing Rules
 
 Header and main content apply `ml`/`mr` margins equal to the sidebar width on large screens. When the sidebar toggles, both elements update using the `sidebar` transition property for smooth motion.
+
+```
+Mini  ───┐ header/main: lg:ml-16  (rtl: lg:mr-16)
+Full  ───┤ header/main: lg:ml-72  (rtl: lg:mr-72)
+```
 
 ## Spinner Usage
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -7,7 +7,7 @@ import AuthModal from '@/components/auth/AuthModal';
 import { cn } from '@/lib/utils';
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { language, theme, sidebarOpen } = useAppStore();
+  const { language, theme, sidebarOpen, setSidebarOpen } = useAppStore();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -16,17 +16,27 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     document.documentElement.classList.add('antialiased');
   }, [theme, language]);
 
+  // set initial sidebar state based on screen width
+  useEffect(() => {
+    const width = window.innerWidth;
+    if (width >= 1536) {
+      setSidebarOpen(true);
+    } else {
+      setSidebarOpen(false);
+    }
+  }, [setSidebarOpen]);
+
   const isRTL = language === 'ar';
 
   const marginClasses = cn(
     'transition-all duration-200 ease-in-out',
     sidebarOpen
       ? isRTL
-        ? '2xl:mr-72'
-        : '2xl:ml-72'
+        ? 'lg:mr-72'
+        : 'lg:ml-72'
       : isRTL
-        ? 'lg:mr-16 2xl:mr-16'
-        : 'lg:ml-16 2xl:ml-16'
+        ? 'lg:mr-16'
+        : 'lg:ml-16'
   );
 
   return (
@@ -41,10 +51,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
       {/* Main Content Area */}
       <div
-        className={cn(
-          'flex flex-col flex-1 min-h-screen transition-all duration-200 ease-in-out',
-          marginClasses
-        )}
+        className="flex flex-col flex-1 min-h-screen transition-all duration-200 ease-in-out"
       >
         {/* Topbar */}
         <Topbar className={marginClasses} />

--- a/src/components/layout/SidebarRail.tsx
+++ b/src/components/layout/SidebarRail.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { motion, Variants } from 'framer-motion';
+import React, { useEffect, useRef } from 'react';
+import { motion } from 'framer-motion';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
@@ -18,43 +18,42 @@ export const SidebarRail: React.FC = () => {
   const location = useLocation();
   const { t } = useTranslation();
   const isRTL = language === 'ar';
+  const ref = useRef<HTMLDivElement>(null);
 
-  const sidebarVariants: Variants = {
-    open: {},
-    closed: {}
-  };
+  // close when clicking outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setSidebarOpen(false);
+      }
+    }
+    if (sidebarOpen) document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [sidebarOpen, setSidebarOpen]);
+
+  const sidebarClasses = cn(
+    'fixed top-0 z-50 h-screen bg-sidebar border-sidebar-border shadow-xl flex flex-col',
+    'transition-all duration-200 ease-in-out',
+    isRTL ? 'right-0 border-l' : 'left-0 border-r',
+    sidebarOpen ? 'w-full lg:w-sidebar-full' : 'w-full lg:w-sidebar-mini',
+    sidebarOpen ? 'translate-x-0' : isRTL ? 'translate-x-full lg:translate-x-0' : '-translate-x-full lg:translate-x-0'
+  );
 
   return (
     <>
-      {/* Overlay for mobile */}
       {sidebarOpen && (
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm block xl:hidden transition-all duration-200 ease-in-out"
+          className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm lg:hidden transition-all duration-200 ease-in-out"
           onClick={() => setSidebarOpen(false)}
         />
       )}
 
-      <motion.aside
-        initial={false}
-        variants={sidebarVariants}
-        animate={sidebarOpen ? 'open' : 'closed'}
-        className={cn(
-          'fixed top-0 z-50 h-screen bg-sidebar border-sidebar-border shadow-xl flex flex-col',
-          'transition-all duration-200 ease-in-out',
-          isRTL ? 'right-0 border-l' : 'left-0 border-r',
-          sidebarOpen ? 'w-full xl:w-sidebar-full' : 'w-sidebar-mini',
-          'xl:translate-x-0',
-          sidebarOpen ? '' : isRTL ? 'translate-x-full xl:translate-x-0' : '-translate-x-full xl:translate-x-0',
-          'flex'
-        )}
-        role="navigation"
-        aria-label={t('navigation.main')}
-      >
+      <motion.aside ref={ref} className={sidebarClasses} role="navigation" aria-label={t('navigation.main')}>
         <div className="flex-1 overflow-y-auto px-3 py-4">
-          {sidebarConfig.groups.map(group => (
+          {sidebarConfig.groups.map((group) => (
             <SidebarNavGroup
               key={group.label}
               group={group}

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -81,6 +81,7 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
             size="sm"
             onClick={toggleSidebar}
             className={cn(language === 'ar' ? 'ml-auto' : 'mr-auto')}
+            aria-label="Toggle sidebar"
           >
             <Menu className="w-5 h-5" />
           </Button>

--- a/src/components/layout/modernSidebar/SidebarNavItem.tsx
+++ b/src/components/layout/modernSidebar/SidebarNavItem.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { SidebarItem } from './types';
 import { useLoadingStore } from '@/stores/useLoadingStore';
+import { useAppStore } from '@/stores/useAppStore';
 
 interface SidebarNavItemProps {
   item: SidebarItem;
@@ -18,6 +19,7 @@ interface SidebarNavItemProps {
 export function SidebarNavItem({ item, isCollapsed, isActive, isRTL }: SidebarNavItemProps) {
   const { t } = useTranslation();
   const showLoading = useLoadingStore((state) => state.showLoading);
+  const { setSidebarOpen } = useAppStore();
 
   const NavItemContent = (
     <motion.div
@@ -90,7 +92,10 @@ export function SidebarNavItem({ item, isCollapsed, isActive, isRTL }: SidebarNa
   const navLink = (
     <NavLink
       to={item.href}
-      onClick={showLoading}
+      onClick={() => {
+        showLoading();
+        setSidebarOpen(false);
+      }}
       className="block"
       aria-label={t(item.label)}
     >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,10 @@ export default {
 			}
 		},
                 extend: {
+                        spacing: {
+                                'sidebar-mini': '4rem',
+                                'sidebar-full': '18rem',
+                        },
                         width: {
                                 'sidebar-mini': '4rem',
                                 'sidebar-full': '18rem',


### PR DESCRIPTION
## Summary
- refactor sidebar rails and layout margins for mini and full states
- close sidebar on nav click
- add aria-label to sidebar toggle button
- define sidebar spacing tokens in tailwind config
- update style guide with breakpoint diagrams

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855f5cb1c548330b73beda1d6580565