### PR TITLE
Refined dashboard layout and theme

### DIFF
--- a/docs/theme-preview.md
+++ b/docs/theme-preview.md
@@ -1,0 +1,17 @@
+# Theme Preview
+
+The design system defines matching light and dark palettes using CSS variables.
+The snippet below demonstrates the two modes side by side.
+
+```html
+<div class="flex gap-4">
+  <div class="p-4 rounded-lg bg-[hsl(var(--color-bg))] text-[hsl(var(--color-text))] shadow">
+    Light mode
+  </div>
+  <div class="p-4 rounded-lg bg-[hsl(var(--color-bg))] text-[hsl(var(--color-text))] shadow dark">
+    Dark mode
+  </div>
+</div>
+```
+
+Applying the `dark` class will toggle all variables and transition smoothly.

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -89,7 +89,7 @@ export function AppHeader() {
       <header className={`h-16 border-b border-gray-200 dark:border-gray-800 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md sticky top-0 z-40 ${isRTL ? 'border-l' : 'border-r'}`}>
         <div className={`flex items-center justify-between h-full px-4 ${isRTL ? 'flex-row-reverse' : ''}`}>
           {/* Left section */}
-          <div className={`flex items-center space-x-3 ${isRTL ? 'space-x-reverse' : ''}`}>
+          <div className={`flex items-center gap-3 ${isRTL ? 'flex-row-reverse' : ''}`}>
             <Button
               variant="ghost"
               size="sm"
@@ -98,6 +98,12 @@ export function AppHeader() {
             >
               <Menu className="h-5 w-5" />
             </Button>
+
+            {/* Logos */}
+            <div className={`flex items-center gap-2 ${isRTL ? 'flex-row-reverse' : ''}`}>
+              <img src="/logo-day.png" alt="Logo" className="h-8 w-auto" />
+              <img src="/logo-patrens.png" alt="Mark" className="h-8 w-auto" />
+            </div>
             
             <div className={`hidden md:flex items-center space-x-2 ${isRTL ? 'space-x-reverse' : ''}`}>
               {quickActions.map((action, index) => (
@@ -128,13 +134,13 @@ export function AppHeader() {
           </div>
 
           {/* Right section */}
-          <div className={`flex items-center space-x-2 ${isRTL ? 'space-x-reverse' : ''}`}>
+          <div className={`flex items-center gap-2 ${isRTL ? 'flex-row-reverse' : ''}`}>
             {/* Style Control Panel */}
             <Button
               variant="ghost"
               size="icon"
               onClick={() => setIsStylePanelOpen(true)}
-              className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+              className="w-10 h-10 p-2 rounded-full backdrop-blur-sm bg-white/40 dark:bg-gray-700/40 hover:bg-white/60 dark:hover:bg-gray-600/60 transition-colors"
             >
               <Palette className="h-5 w-5 text-gray-600 dark:text-gray-400" />
             </Button>
@@ -144,13 +150,13 @@ export function AppHeader() {
               variant="ghost"
               size="icon"
               onClick={toggleLanguage}
-              className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+              className="w-10 h-10 p-2 rounded-full backdrop-blur-sm bg-white/40 dark:bg-gray-700/40 hover:bg-white/60 dark:hover:bg-gray-600/60 transition-colors"
             >
               <Languages className="h-5 w-5 text-gray-600 dark:text-gray-400" />
             </Button>
 
             {/* Notifications */}
-            <Button variant="ghost" size="icon" className="relative hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full">
+            <Button variant="ghost" size="icon" className="relative w-10 h-10 p-2 rounded-full backdrop-blur-sm bg-white/40 dark:bg-gray-700/40 hover:bg-white/60 dark:hover:bg-gray-600/60 transition-colors">
               <Bell className="h-5 w-5 text-gray-600 dark:text-gray-400" />
               <Badge className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 bg-red-500 text-white text-xs">
                 3
@@ -162,7 +168,7 @@ export function AppHeader() {
               variant="ghost"
               size="icon"
               onClick={toggleTheme}
-              className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+              className="w-10 h-10 p-2 rounded-full backdrop-blur-sm bg-white/40 dark:bg-gray-700/40 hover:bg-white/60 dark:hover:bg-gray-600/60 transition-colors"
             >
               {theme === 'dark' ? (
                 <Sun className="h-5 w-5 text-gray-600 dark:text-gray-400" />
@@ -174,7 +180,7 @@ export function AppHeader() {
             {/* User menu */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="flex items-center space-x-2 space-x-reverse hover:bg-background-desktop rounded-xl p-2">
+                <Button variant="ghost" className="flex items-center gap-2 p-2 w-10 h-10 rounded-full backdrop-blur-sm bg-white/40 dark:bg-gray-700/40 hover:bg-white/60 dark:hover:bg-gray-600/60 transition-colors">
                   <div className="w-8 h-8 bg-gradient-to-r from-primary to-accent rounded-full flex items-center justify-center">
                     <User className="h-4 w-4 text-white" />
                   </div>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useAppStore } from '@/stores/useAppStore';
 import SidebarRail from './SidebarRail';
-import Topbar from './Topbar';
+import { AppHeader } from './AppHeader';
 import AuthModal from '@/components/auth/AuthModal';
 import { cn } from '@/lib/utils';
 
@@ -51,8 +51,8 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         'flex flex-col flex-1 min-h-screen transition-all duration-200 ease-in-out',
         marginClasses
       )}>
-        {/* Topbar */}
-        <Topbar />
+        {/* Header */}
+        <AppHeader />
 
         {/* محتوى الصفحة */}
         <main className="flex-1 overflow-auto bg-gradient-to-br from-background to-muted/20 transition-all">

--- a/src/components/layout/modernSidebar/sidebarConfig.ts
+++ b/src/components/layout/modernSidebar/sidebarConfig.ts
@@ -4,9 +4,9 @@ import {
   Calendar,
   Users,
   Waves,
-  Target,
-  CreditCard,
-  BarChart3,
+  MapPin,
+  Wallet,
+  LineChart,
   Settings,
   Shield,
   UserCheck
@@ -16,7 +16,7 @@ import { SidebarConfig } from './types';
 export const sidebarConfig: SidebarConfig = {
   groups: [
     {
-      label: 'navigation.main',
+      label: 'sidebar.general',
       items: [
         {
           href: '/',
@@ -32,7 +32,7 @@ export const sidebarConfig: SidebarConfig = {
       ]
     },
     {
-      label: 'navigation.activities',
+      label: 'sidebar.activities',
       items: [
         {
           href: '/activities/swimming',
@@ -42,12 +42,12 @@ export const sidebarConfig: SidebarConfig = {
         {
           href: '/activities/fields',
           label: 'navigation.fields',
-          icon: Target
+          icon: MapPin
         }
       ]
     },
     {
-      label: 'navigation.management',
+      label: 'sidebar.management',
       items: [
         {
           href: '/clients',
@@ -57,17 +57,17 @@ export const sidebarConfig: SidebarConfig = {
         {
           href: '/payments',
           label: 'navigation.payments',
-          icon: CreditCard
+          icon: Wallet
         },
         {
           href: '/reports',
           label: 'navigation.reports',
-          icon: BarChart3
+          icon: LineChart
         }
       ]
     },
     {
-      label: 'navigation.system',
+      label: 'sidebar.system',
       items: [
         {
           href: '/users',

--- a/src/components/panels/StyleControlPanel.tsx
+++ b/src/components/panels/StyleControlPanel.tsx
@@ -63,9 +63,9 @@ export function StyleControlPanel({ isOpen, onClose }: StyleControlPanelProps) {
 
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
-      <SheetContent 
-        side={isRTL ? "left" : "right"} 
-        className="w-96 overflow-y-auto bg-white/95 dark:bg-gray-900/95 backdrop-blur-md border-gray-200 dark:border-gray-800"
+      <SheetContent
+        side={isRTL ? "left" : "right"}
+        className="w-96 overflow-y-auto bg-white/95 dark:bg-gray-900/95 backdrop-blur-md border-gray-200 dark:border-gray-800 z-50"
       >
         <SheetHeader className={isRTL ? 'text-right' : 'text-left'}>
           <SheetTitle className={`flex items-center space-x-2 ${isRTL ? 'space-x-reverse' : ''}`}>

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,17 @@
     --surface-50: #f8fafc;
     --surface-100: #f1f5f9;
     --surface-200: #e2e8f0;
+
+    /* Semantic aliases */
+    --color-bg: var(--background-color);
+    --color-surface: var(--surface);
+    --color-text: var(--text-color);
+    --color-primary: var(--primary-color);
+    --color-accent: var(--accent-color);
+    --color-muted: var(--muted);
+
+    /* backward compatibility */
+    --text-color: var(--color-text);
   }
 
   .dark {
@@ -114,6 +125,14 @@
     --surface-50: #1e293b;
     --surface-100: #334155;
     --surface-200: #475569;
+
+    --color-bg: var(--background-color);
+    --color-surface: var(--surface);
+    --color-text: var(--text-color);
+    --color-primary: var(--primary-color);
+    --color-accent: var(--accent-color);
+    --color-muted: var(--muted);
+    --text-color: var(--color-text);
   }
 }
 
@@ -126,6 +145,7 @@
   html {
     scroll-behavior: smooth;
     font-feature-settings: "cv03", "cv04", "cv11";
+    transition: background-color 0.3s ease, color 0.3s ease;
   }
 
   body {

--- a/src/translations/ar.json
+++ b/src/translations/ar.json
@@ -13,6 +13,12 @@
     "profile": "الملف الشخصي",
     "settings": "الإعدادات"
   },
+  "sidebar": {
+    "general": "عام",
+    "activities": "الأنشطة",
+    "management": "الإدارة",
+    "system": "النظام"
+  },
   "common": {
     "login": "تسجيل الدخول",
     "logout": "تسجيل الخروج",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -13,6 +13,12 @@
     "profile": "Profile",
     "settings": "Settings"
   },
+  "sidebar": {
+    "general": "General",
+    "activities": "Activities",
+    "management": "Management",
+    "system": "System"
+  },
   "common": {
     "login": "Login",
     "logout": "Logout",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -65,7 +65,12 @@ export default {
                                 background: 'hsl(var(--background))',
                                 'background-desktop': 'hsl(var(--background-color-desktop))',
                                 foreground: 'hsl(var(--foreground))',
-                                text: 'hsl(var(--text-color))',
+                                text: 'hsl(var(--color-text))',
+                                bg: 'hsl(var(--color-bg))',
+                                surface: 'hsl(var(--color-surface))',
+                                'primary-brand': 'hsl(var(--color-primary))',
+                                'accent-brand': 'hsl(var(--color-accent))',
+                                'brand-muted': 'hsl(var(--color-muted))',
                                 primary: {
                                         DEFAULT: 'hsl(var(--primary))',
                                         foreground: 'hsl(var(--primary-foreground))'


### PR DESCRIPTION
## Summary
- switch Layout to use `AppHeader`
- brand AppHeader with dual logos and polished mini-bar buttons
- update sidebar labels and icons
- expose theme variables with semantic CSS custom props
- document light/dark preview snippet

## Testing
- `yarn lint` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855fee844ac8330a694295493bb3426