### PR TITLE
Refine layout branding and theme

### DIFF
--- a/docs/theme-preview.md
+++ b/docs/theme-preview.md
@@ -4,12 +4,12 @@ The design system defines matching light and dark palettes using CSS variables.
 The snippet below demonstrates the two modes side by side.
 
 ```html
-<div class="flex gap-4">
-  <div class="p-4 rounded-lg bg-[hsl(var(--color-bg))] text-[hsl(var(--color-text))] shadow">
-    Light mode
+<div class="flex gap-6">
+  <div class="p-6 rounded-lg bg-[hsl(var(--color-bg))] text-[hsl(var(--color-text))] shadow w-40 text-center">
+    Light
   </div>
-  <div class="p-4 rounded-lg bg-[hsl(var(--color-bg))] text-[hsl(var(--color-text))] shadow dark">
-    Dark mode
+  <div class="p-6 rounded-lg bg-[hsl(var(--color-bg))] text-[hsl(var(--color-text))] shadow dark w-40 text-center">
+    Dark
   </div>
 </div>
 ```

--- a/public/logo-secondary.svg
+++ b/public/logo-secondary.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32" fill="currentColor">
+  <rect width="120" height="32" rx="6" fill="url(#grad)"/>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="120" y2="32" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1D4ED8"/>
+      <stop offset="1" stop-color="#9333EA"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -92,9 +92,9 @@ export function AppHeader() {
           <div className={`flex items-center space-x-3 ${isRTL ? 'space-x-reverse' : ''}`}>
             <Button
               variant="ghost"
-              size="sm"
+              size="icon"
               onClick={toggleSidebar}
-              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+              className="backdrop-blur-md bg-background/60 hover:bg-background/70 transition-colors"
             >
               <Menu className="h-5 w-5" />
             </Button>
@@ -134,9 +134,9 @@ export function AppHeader() {
               variant="ghost"
               size="icon"
               onClick={() => setIsStylePanelOpen(true)}
-              className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+              className="backdrop-blur-md bg-background/60 hover:bg-background/70 transition-colors rounded-full"
             >
-              <Palette className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <Palette className="h-5 w-5" />
             </Button>
 
             {/* Language toggle */}
@@ -144,14 +144,14 @@ export function AppHeader() {
               variant="ghost"
               size="icon"
               onClick={toggleLanguage}
-              className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+              className="backdrop-blur-md bg-background/60 hover:bg-background/70 transition-colors rounded-full"
             >
-              <Languages className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <Languages className="h-5 w-5" />
             </Button>
 
             {/* Notifications */}
-            <Button variant="ghost" size="icon" className="relative hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full">
-              <Bell className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <Button variant="ghost" size="icon" className="relative backdrop-blur-md bg-background/60 hover:bg-background/70 transition-colors rounded-full">
+              <Bell className="h-5 w-5" />
               <Badge className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 bg-red-500 text-white text-xs">
                 3
               </Badge>
@@ -162,19 +162,22 @@ export function AppHeader() {
               variant="ghost"
               size="icon"
               onClick={toggleTheme}
-              className="hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+              className="backdrop-blur-md bg-background/60 hover:bg-background/70 transition-colors rounded-full"
             >
               {theme === 'dark' ? (
-                <Sun className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+                <Sun className="h-5 w-5" />
               ) : (
-                <Moon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+                <Moon className="h-5 w-5" />
               )}
             </Button>
 
             {/* User menu */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="flex items-center space-x-2 space-x-reverse hover:bg-background-desktop rounded-xl p-2">
+                <Button
+                  variant="ghost"
+                  className="flex items-center space-x-2 space-x-reverse backdrop-blur-md bg-background/60 hover:bg-background/70 transition-colors p-2 rounded-xl"
+                >
                   <div className="w-8 h-8 bg-gradient-to-r from-primary to-accent rounded-full flex items-center justify-center">
                     <User className="h-4 w-4 text-white" />
                   </div>

--- a/src/components/layout/SidebarRail.tsx
+++ b/src/components/layout/SidebarRail.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import { useAppStore } from '@/stores/useAppStore';
 import { SidebarNavGroup } from './modernSidebar/SidebarNavGroup';
 import { sidebarConfig } from './modernSidebar/sidebarConfig';
+import { SidebarHeader } from './modernSidebar/SidebarHeader';
 
 /**
  * SidebarRail handles responsive sidebar behaviour.
@@ -52,6 +53,7 @@ export const SidebarRail: React.FC = () => {
       )}
 
       <motion.aside ref={ref} className={sidebarClasses} role="navigation" aria-label={t('navigation.main')}>
+        <SidebarHeader />
         <div className="flex-1 overflow-y-auto px-3 py-4">
           {sidebarConfig.groups.map((group) => (
             <SidebarNavGroup

--- a/src/components/layout/modernSidebar/SidebarHeader.tsx
+++ b/src/components/layout/modernSidebar/SidebarHeader.tsx
@@ -19,19 +19,11 @@ export function SidebarHeader() {
     >
       {sidebarOpen ? (
         <div className="flex items-center gap-2">
-          <img src="/logo-day.png" alt="Sports Hub" className="h-10 w-auto" />
-          <img
-            src="/logo-patrens.png"
-            alt="Sports Hub mark"
-            className="h-10 w-auto"
-          />
+          <AppLogo className="h-8" />
+          <AppLogo variant="secondary" className="h-8" />
         </div>
       ) : (
-        <img
-          src="/logo-patrens.png"
-          alt="Sports Hub mark"
-          className="h-8 w-auto"
-        />
+        <AppLogo variant="secondary" className="h-8" />
       )}
 
       {sidebarOpen && (

--- a/src/components/ui/AppLogo.tsx
+++ b/src/components/ui/AppLogo.tsx
@@ -1,27 +1,26 @@
 // src/components/ui/AppLogo.tsx
 import React from 'react';
 import { useAppStore } from '@/stores/useAppStore';
+import { cn } from '@/lib/utils';
 
 type Props = {
-  location: 'topbar' | 'sidebar';
+  /**
+   * Primary displays the wordmark while secondary
+   * renders the compact brand mark used in sidebars.
+   */
+  variant?: 'primary' | 'secondary';
   className?: string;
 };
 
-const AppLogo = ({ location, className = '' }: Props) => {
+const AppLogo = ({ variant = 'primary', className = '' }: Props) => {
   const { theme } = useAppStore();
 
-  // Topbar: show logo based on theme
-  if (location === 'topbar') {
+  if (variant === 'primary') {
     const src = theme === 'dark' ? '/logo-dark.png' : '/logo-day.png';
-    return <img src={src} alt="App Logo" className={`h-8 w-auto ${className}`} />;
+    return <img src={src} alt="Sports Hub" className={cn('h-8 w-auto', className)} />;
   }
 
-  // Sidebar: use pattern logo
-  if (location === 'sidebar') {
-    return <img src="/logo-patrens.png" alt="App Pattern Logo" className={`h-10 w-auto ${className}`} />;
-  }
-
-  return null;
+  return <img src="/logo-secondary.svg" alt="Sports Hub Mark" className={cn('h-8 w-auto', className)} />;
 };
 
 export default AppLogo;

--- a/src/index.css
+++ b/src/index.css
@@ -142,7 +142,7 @@
   }
 
   body {
-    @apply bg-background text-foreground antialiased lg:bg-[hsl(var(--background-color-desktop))];
+    @apply bg-background text-foreground antialiased transition-colors lg:bg-[hsl(var(--background-color-desktop))];
     font-feature-settings: "rlig" 1, "calt" 1;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   }


### PR DESCRIPTION
## Summary
- support primary and secondary logos via `AppLogo` component
- show both logos in sidebar header
- display sidebar header in the rail
- improve header mini-bar styling
- smooth body color transitions
- adjust theme demo snippet

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68560bb8120c8330b6d337cc83b2b07a