### PR TITLE
Fix responsive header layout

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -35,8 +35,7 @@ import { useLoadingStore } from '@/stores/useLoadingStore';
 
 export function AppHeader() {
   const { theme, setTheme } = useTheme();
-  const { toggleSidebar } = useAppStore();
-  const { language, setLanguage, user, logout } = useAppStore();
+  const { toggleSidebar, sidebarOpen, language, setLanguage, user, logout } = useAppStore();
   const navigate = useNavigate();
   const { toast } = useToast();
   const showLoading = useLoadingStore((state) => state.showLoading);
@@ -44,6 +43,14 @@ export function AppHeader() {
   const [isStylePanelOpen, setIsStylePanelOpen] = useState(false);
 
   const isRTL = language === 'ar';
+
+  const headerPadding = sidebarOpen
+    ? isRTL
+      ? 'lg:pr-72'
+      : 'lg:pl-72'
+    : isRTL
+      ? 'lg:pr-16'
+      : 'lg:pl-16';
 
   const quickActions = [
     {
@@ -86,7 +93,9 @@ export function AppHeader() {
 
   return (
     <>
-      <header className={`h-16 border-b border-gray-200 dark:border-gray-800 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md sticky top-0 z-40 ${isRTL ? 'border-l' : 'border-r'}`}>
+      <header
+        className={`fixed top-0 inset-x-0 h-16 z-50 border-b border-gray-200 dark:border-gray-800 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md ${headerPadding} ${isRTL ? 'border-l' : 'border-r'}`}
+      >
         <div className={`flex items-center justify-between h-full px-4 ${isRTL ? 'flex-row-reverse' : ''}`}>
           {/* Left section */}
           <div className={`flex items-center space-x-3 ${isRTL ? 'space-x-reverse' : ''}`}>
@@ -187,7 +196,7 @@ export function AppHeader() {
                   </div>
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+              <DropdownMenuContent align="end" className="z-50 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
                 <DropdownMenuItem className="flex items-center space-x-2 space-x-reverse">
                   <User className="h-4 w-4" />
                   <span>الملف الشخصي</span>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -28,15 +28,15 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   const isRTL = language === 'ar';
 
-  const marginClasses = cn(
-    'transition-all duration-200 ease-in-out',
+  const offsetClasses = cn(
+    'transition-[padding] duration-200 ease-in-out',
     sidebarOpen
       ? isRTL
-        ? 'lg:mr-72'
-        : 'lg:ml-72'
+        ? 'lg:pr-72'
+        : 'lg:pl-72'
       : isRTL
-        ? 'lg:mr-16'
-        : 'lg:ml-16'
+        ? 'lg:pr-16'
+        : 'lg:pl-16'
   );
 
   return (
@@ -50,14 +50,12 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <SidebarRail />
 
       {/* Main Content Area */}
-      <div
-        className="flex flex-col flex-1 min-h-screen transition-all duration-200 ease-in-out"
-      >
+      <div className="flex flex-col flex-1 min-h-screen relative">
         {/* Topbar */}
-        <Topbar className={marginClasses} />
-        
+        <Topbar className={cn('fixed top-0 inset-x-0 z-40', offsetClasses)} />
+
         {/* Page Content */}
-        <main className={cn('flex-1 overflow-auto bg-gradient-to-br from-background to-muted/20', marginClasses)}>
+        <main className={cn('flex-1 pt-16 overflow-auto bg-gradient-to-br from-background to-muted/20', offsetClasses)}>
           <div className="container mx-auto p-6 max-w-7xl">
             {children}
           </div>


### PR DESCRIPTION
## Summary
- make layout header full width with fixed top bar
- adjust content padding with sidebar state
- allow AppHeader dropdowns to overlay sidebar

## Testing
- `yarn lint` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856173b52b4833085312665b0023692