### PR TITLE
Fix header padding and dropdown

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -28,15 +28,15 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   const isRTL = language === 'ar';
 
-  const marginClasses = cn(
+  const paddingClasses = cn(
     'transition-all duration-200 ease-in-out',
     sidebarOpen
       ? isRTL
-        ? 'lg:mr-72'
-        : 'lg:ml-72'
+        ? 'lg:pr-72'
+        : 'lg:pl-72'
       : isRTL
-        ? 'lg:mr-16'
-        : 'lg:ml-16'
+        ? 'lg:pr-16'
+        : 'lg:pl-16'
   );
 
   return (
@@ -54,10 +54,10 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         className="flex flex-col flex-1 min-h-screen transition-all duration-200 ease-in-out"
       >
         {/* Topbar */}
-        <Topbar className={marginClasses} />
+        <Topbar className={paddingClasses} />
         
         {/* Page Content */}
-        <main className={cn('flex-1 overflow-auto bg-gradient-to-br from-background to-muted/20', marginClasses)}>
+        <main className={cn('flex-1 overflow-auto bg-gradient-to-br from-background to-muted/20', paddingClasses)}>
           <div className="container mx-auto p-6 max-w-7xl">
             {children}
           </div>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -67,7 +67,7 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
   return (
     <motion.header
       className={cn(
-        'sticky top-0 z-30 w-full border-b shadow-sm border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
+        'sticky top-0 z-[60] w-full border-b shadow-sm border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
         className
       )}
       initial={{ y: -100 }}
@@ -142,9 +142,9 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
                   </div>
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent 
-                align="end" 
-                className="w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
+              <DropdownMenuContent
+                align="end"
+                className="z-[70] w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
               >
                 <DropdownMenuItem 
                   onClick={handleProfile}


### PR DESCRIPTION
## Summary
- keep header full width by switching margin to padding in `Layout`
- ensure header stays above sidebar and dropdown isn't clipped
- bump dropdown z-index

## Testing
- `yarn lint` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_68561a125e7c8330b869c23c50f238f8