### PR TITLE
Add gradient theming and admin dashboard translations

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -13,6 +13,10 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
     document.documentElement.dir = language === 'ar' ? 'rtl' : 'ltr';
     document.documentElement.lang = language;
+    document.documentElement.style.setProperty(
+      '--gradient-direction',
+      language === 'ar' ? 'to left' : 'to right'
+    );
     document.documentElement.classList.add('antialiased');
   }, [theme, language]);
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -59,7 +59,7 @@ const Sidebar = () => {
         variants={sidebarVariants}
         animate={sidebarOpen ? "open" : "closed"}
         className={cn(
-          'fixed inset-y-0 flex w-64 flex-col bg-sidebar text-sidebar-foreground shadow-md transition-transform duration-300 lg:sticky lg:left-0 lg:top-0 lg:z-auto lg:translate-x-0',
+          'fixed inset-y-0 flex w-64 flex-col sidebar-gradient text-sidebar-foreground shadow-md transition-transform duration-300 lg:sticky lg:left-0 lg:top-0 lg:z-auto lg:translate-x-0 dark:neon-shadow',
           language === 'ar' ? 'right-0' : 'left-0'
         )}
       >
@@ -85,7 +85,7 @@ const Sidebar = () => {
                       )
                     }
                   >
-                    <Icon className="w-5 h-5" />
+                    <Icon className="w-5 h-5 dark:text-fuchsia-400" />
                     <span>{item.label}</span>
                   </NavLink>
                   {item.subItems && (
@@ -103,7 +103,7 @@ const Sidebar = () => {
                             )
                           }
                         >
-                          <sub.icon className="w-4 h-4" />
+                          <sub.icon className="w-4 h-4 dark:text-fuchsia-400" />
                           {sub.label}
                         </NavLink>
                       ))}

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -67,7 +67,8 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
   return (
     <motion.header
       className={cn(
-        'sticky top-0 z-30 w-full border-b shadow-sm border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900',
+        'sticky top-0 z-30 w-full border-b border-gray-200 dark:border-gray-700 header-gradient dark:neon-shadow',
+        'shadow-sm',
         className
       )}
       initial={{ y: -100 }}
@@ -86,7 +87,7 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
             )}
             aria-label="Toggle sidebar"
           >
-            <Menu className="w-5 h-5" />
+            <Menu className="w-5 h-5 dark:text-fuchsia-400" />
           </Button>
         </div>
 
@@ -98,7 +99,7 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
             onClick={handleLanguageToggle}
             className="rounded-lg backdrop-blur-md bg-white/40 dark:bg-gray-800/40 hover:bg-white/60 dark:hover:bg-gray-700/60 transition-colors"
           >
-            <Globe className="w-4 h-4" />
+            <Globe className="w-4 h-4 dark:text-fuchsia-400" />
           </Button>
 
           {/* Theme Switch */}
@@ -108,7 +109,7 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
             onClick={toggleTheme}
             className="rounded-lg backdrop-blur-md bg-white/40 dark:bg-gray-800/40 hover:bg-white/60 dark:hover:bg-gray-700/60 transition-colors"
           >
-            {theme === 'light' ? <Moon className="w-4 h-4" /> : <Sun className="w-4 h-4" />}
+            {theme === 'light' ? <Moon className="w-4 h-4 dark:text-fuchsia-400" /> : <Sun className="w-4 h-4 dark:text-fuchsia-400" />}
           </Button>
 
           {/* Notifications */}
@@ -118,7 +119,7 @@ const Topbar: React.FC<TopbarProps> = ({ className }) => {
             className="rounded-lg backdrop-blur-md bg-white/40 dark:bg-gray-800/40 hover:bg-white/60 dark:hover:bg-gray-700/60 transition-colors"
             aria-label="Notifications"
           >
-            <Bell className="w-4 h-4" />
+            <Bell className="w-4 h-4 dark:text-fuchsia-400" />
           </Button>
 
           {/* User Menu */}

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,12 @@
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
 
+    /* Gradient variables */
+    --gradient-direction: to right;
+    --header-gradient: linear-gradient(var(--gradient-direction), #f8fafc, #e0f2fe);
+    --sidebar-gradient: linear-gradient(var(--gradient-direction), #ffffff, #f1f5f9);
+    --neon-glow: 0 0 12px rgba(124, 58, 237, 0.7);
+
     /* Custom surface colors */
     --surface: #ffffff;
     --surface-50: #f8fafc;
@@ -126,6 +132,9 @@
     --surface-50: #1e293b;
     --surface-100: #334155;
     --surface-200: #475569;
+
+    --header-gradient: linear-gradient(var(--gradient-direction), #1f2937, #4b5563);
+    --sidebar-gradient: linear-gradient(var(--gradient-direction), #111827, #1f2937);
   }
 }
 
@@ -200,6 +209,18 @@
   /* Layout utilities */
   .page-container {
     @apply mx-auto max-w-screen-2xl px-4 sm:px-6 lg:px-8;
+  }
+
+  .header-gradient {
+    background-image: var(--header-gradient);
+  }
+
+  .sidebar-gradient {
+    background-image: var(--sidebar-gradient);
+  }
+
+  .neon-shadow {
+    box-shadow: var(--neon-glow);
   }
 
   .content-wrapper {
@@ -292,10 +313,12 @@
 
 /* RTL specific overrides */
 [dir="rtl"] {
+  --gradient-direction: to left;
+
   .text-left {
     text-align: right;
   }
-  
+
   .text-right {
     text-align: left;
   }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -142,6 +142,25 @@ const resources = {
       lightMode: "Light Mode",
       darkMode: "Dark Mode",
       language: "Language",
+
+      // Admin Dashboard
+      'dashboard.totalBookings': 'Total Bookings',
+      'dashboard.activeMembers': 'Active Members',
+      'dashboard.monthlyRevenue': 'Monthly Revenue',
+      'dashboard.occupancyRate': 'Occupancy Rate',
+      'dashboard.monthlyBookingsTrend': 'Monthly Bookings Trend',
+      'dashboard.bookingVolumeDesc': 'Booking volume over the last 6 months',
+      'dashboard.revenueVsTarget': 'Revenue vs Target',
+      'dashboard.revenuePerformanceDesc': 'Monthly revenue performance against targets',
+      'dashboard.activityDistribution': 'Activity Distribution',
+      'dashboard.bookingDistributionDesc': 'Booking distribution by sport type',
+      'dashboard.weeklyUsagePattern': 'Weekly Usage Pattern',
+      'dashboard.usagePatternDesc': 'Hourly booking patterns throughout the week',
+      'dashboard.exportReport': 'Export Report',
+      'dashboard.filter': 'Filter',
+      'dashboard.morning': 'Morning',
+      'dashboard.afternoon': 'Afternoon',
+      'dashboard.evening': 'Evening',
     }
   },
   ar: {
@@ -284,6 +303,25 @@ const resources = {
       lightMode: "الوضع الفاتح",
       darkMode: "الوضع المظلم",
       language: "اللغة",
+
+      // Admin Dashboard
+      'dashboard.totalBookings': 'إجمالي الحجوزات',
+      'dashboard.activeMembers': 'الأعضاء النشطون',
+      'dashboard.monthlyRevenue': 'الإيرادات الشهرية',
+      'dashboard.occupancyRate': 'معدل الإشغال',
+      'dashboard.monthlyBookingsTrend': 'اتجاه الحجوزات الشهري',
+      'dashboard.bookingVolumeDesc': 'حجم الحجوزات خلال آخر 6 أشهر',
+      'dashboard.revenueVsTarget': 'الإيرادات مقابل الهدف',
+      'dashboard.revenuePerformanceDesc': 'أداء الإيرادات الشهرية مقابل الأهداف',
+      'dashboard.activityDistribution': 'توزيع الأنشطة',
+      'dashboard.bookingDistributionDesc': 'توزيع الحجوزات حسب نوع الرياضة',
+      'dashboard.weeklyUsagePattern': 'نمط الاستخدام الأسبوعي',
+      'dashboard.usagePatternDesc': 'أنماط الحجز حسب ساعات اليوم',
+      'dashboard.exportReport': 'تصدير التقرير',
+      'dashboard.filter': 'تصفية',
+      'dashboard.morning': 'صباحي',
+      'dashboard.afternoon': 'مسائي',
+      'dashboard.evening': 'ليلي',
     }
   }
 };

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -81,7 +81,7 @@ export default function AdminDashboard() {
 
   const stats = [
     {
-      title: 'Total Bookings',
+      title: t('dashboard.totalBookings'),
       value: '2,847',
       change: '+12.5%',
       trend: 'up',
@@ -90,7 +90,7 @@ export default function AdminDashboard() {
       bgGradient: 'from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20'
     },
     {
-      title: 'Active Members',
+      title: t('dashboard.activeMembers'),
       value: '1,234',
       change: '+8.2%',
       trend: 'up',
@@ -99,7 +99,7 @@ export default function AdminDashboard() {
       bgGradient: 'from-emerald-50 to-emerald-100 dark:from-emerald-900/20 dark:to-emerald-800/20'
     },
     {
-      title: 'Monthly Revenue',
+      title: t('dashboard.monthlyRevenue'),
       value: '$26,150',
       change: '+15.3%',
       trend: 'up',
@@ -108,7 +108,7 @@ export default function AdminDashboard() {
       bgGradient: 'from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20'
     },
     {
-      title: 'Occupancy Rate',
+      title: t('dashboard.occupancyRate'),
       value: '87.3%',
       change: '+3.1%',
       trend: 'up',
@@ -129,20 +129,20 @@ export default function AdminDashboard() {
         >
           <div>
             <h1 className="text-4xl font-bold bg-gradient-to-r from-slate-900 via-blue-800 to-indigo-900 dark:from-slate-100 dark:via-blue-200 dark:to-indigo-100 bg-clip-text text-transparent">
-              Sports Analytics Dashboard
+              {t('dashboard.analyticsTitle')}
             </h1>
             <p className="text-slate-600 dark:text-slate-400 text-lg mt-2">
-              Real-time insights into your sports facility performance
+              {t('dashboard.analyticsSubtitle')}
             </p>
           </div>
           <div className="flex gap-3">
             <Button variant="outline" className="gap-2">
               <Filter className="w-4 h-4" />
-              Filter
+              {t('dashboard.filter')}
             </Button>
             <Button className="gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700">
               <Download className="w-4 h-4" />
-              Export Report
+              {t('dashboard.exportReport')}
             </Button>
           </div>
         </motion.div>
@@ -202,13 +202,13 @@ export default function AdminDashboard() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <BarChart3 className="w-5 h-5 text-blue-600" />
-                  Monthly Bookings Trend
+                  {t('dashboard.monthlyBookingsTrend')}
                 </CardTitle>
-                <CardDescription>Booking volume over the last 6 months</CardDescription>
+                <CardDescription>{t('dashboard.bookingVolumeDesc')}</CardDescription>
               </CardHeader>
               <CardContent>
                 <ChartContainer config={{
-                  bookings: { label: "Bookings", color: "hsl(217, 91%, 60%)" }
+                  bookings: { label: t('bookings'), color: 'hsl(217, 91%, 60%)' }
                 }} className="h-[300px]">
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart data={bookingData}>
@@ -241,14 +241,14 @@ export default function AdminDashboard() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <TrendingUp className="w-5 h-5 text-emerald-600" />
-                  Revenue vs Target
+                  {t('dashboard.revenueVsTarget')}
                 </CardTitle>
-                <CardDescription>Monthly revenue performance against targets</CardDescription>
+                <CardDescription>{t('dashboard.revenuePerformanceDesc')}</CardDescription>
               </CardHeader>
               <CardContent>
                 <ChartContainer config={{
-                  revenue: { label: "Revenue", color: "hsl(142, 76%, 36%)" },
-                  target: { label: "Target", color: "hsl(142, 76%, 60%)" }
+                  revenue: { label: t('revenue'), color: 'hsl(142, 76%, 36%)' },
+                  target: { label: t('dashboard.revenueVsTarget'), color: 'hsl(142, 76%, 60%)' }
                 }} className="h-[300px]">
                   <ResponsiveContainer width="100%" height="100%">
                     <LineChart data={revenueData}>
@@ -289,9 +289,9 @@ export default function AdminDashboard() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <Activity className="w-5 h-5 text-purple-600" />
-                  Activity Distribution
+                  {t('dashboard.activityDistribution')}
                 </CardTitle>
-                <CardDescription>Booking distribution by sport type</CardDescription>
+                <CardDescription>{t('dashboard.bookingDistributionDesc')}</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="h-[300px] flex items-center">
@@ -349,15 +349,15 @@ export default function AdminDashboard() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <Calendar className="w-5 h-5 text-orange-600" />
-                  Weekly Usage Pattern
+                  {t('dashboard.weeklyUsagePattern')}
                 </CardTitle>
-                <CardDescription>Hourly booking patterns throughout the week</CardDescription>
+                <CardDescription>{t('dashboard.usagePatternDesc')}</CardDescription>
               </CardHeader>
               <CardContent>
                 <ChartContainer config={{
-                  morning: { label: "Morning", color: "hsl(43, 96%, 56%)" },
-                  afternoon: { label: "Afternoon", color: "hsl(25, 95%, 53%)" },
-                  evening: { label: "Evening", color: "hsl(20, 90%, 48%)" }
+                  morning: { label: t('dashboard.morning'), color: 'hsl(43, 96%, 56%)' },
+                  afternoon: { label: t('dashboard.afternoon'), color: 'hsl(25, 95%, 53%)' },
+                  evening: { label: t('dashboard.evening'), color: 'hsl(20, 90%, 48%)' }
                 }} className="h-[300px]">
                   <ResponsiveContainer width="100%" height="100%">
                     <AreaChart data={weeklyData}>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -148,7 +148,9 @@ export default {
                                 'gradient-chart-blue': 'linear-gradient(180deg, #3b82f6 0%, #1d4ed8 100%)',
                                 'gradient-chart-emerald': 'linear-gradient(180deg, #10b981 0%, #059669 100%)',
                                 'gradient-chart-purple': 'linear-gradient(180deg, #a855f7 0%, #9333ea 100%)',
-                                'gradient-chart-orange': 'linear-gradient(180deg, #f97316 0%, #ea580c 100%)'
+                                'gradient-chart-orange': 'linear-gradient(180deg, #f97316 0%, #ea580c 100%)',
+                                'header-gradient': 'var(--header-gradient)',
+                                'sidebar-gradient': 'var(--sidebar-gradient)'
                         },
                         borderRadius: {
 				lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- create CSS variables for header and sidebar gradients
- configure Tailwind to expose `header-gradient` and `sidebar-gradient`
- adapt Layout to set gradient direction based on language
- style Topbar and Sidebar with gradient backgrounds and neon accents
- localize admin dashboard strings and hook up translations

## Testing
- `yarn lint` *(fails: package missing)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685652876bf083308d8c16f26e5878ef