### PR TITLE
Fix default imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,9 @@ import React, { Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from '@/components/ui/sonner';
-import { Layout } from '@/components/layout/Layout';
-import { LoadingOverlay } from '@/components/LoadingOverlay';
-import { RouteChangeListener } from '@/components/RouteChangeListener';
+import Layout from '@/components/layout/Layout';
+import LoadingOverlay from '@/components/LoadingOverlay';
+import RouteChangeListener from '@/components/RouteChangeListener';
 import './App.css';
 
 // Lazy load pages

--- a/src/pages/Coaches.tsx
+++ b/src/pages/Coaches.tsx
@@ -9,7 +9,7 @@ import { Plus, Edit, Trash2, Users } from 'lucide-react';
 import { coachesService, Coach } from '@/services/coaches';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { CoachForm } from '@/components/forms/CoachForm';
-import { ConfirmDeleteModal } from '@/components/forms/ConfirmDeleteModal';
+import ConfirmDeleteModal from '@/components/forms/ConfirmDeleteModal';
 import { toast } from 'sonner';
 
 const Coaches: React.FC = () => {

--- a/src/pages/Players.tsx
+++ b/src/pages/Players.tsx
@@ -9,7 +9,7 @@ import { Plus, Edit, Trash2, User } from 'lucide-react';
 import { playersService, Player } from '@/services/players';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { PlayerForm } from '@/components/forms/PlayerForm';
-import { ConfirmDeleteModal } from '@/components/forms/ConfirmDeleteModal';
+import ConfirmDeleteModal from '@/components/forms/ConfirmDeleteModal';
 import { toast } from 'sonner';
 
 const Players: React.FC = () => {


### PR DESCRIPTION
## Summary
- correct default import syntax for Layout, LoadingOverlay, and RouteChangeListener
- update import style for `ConfirmDeleteModal` in Coaches and Players pages

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68569eacf4088330afa5a23c6c3ccc7f