### PR TITLE
Improve dashboard layout spacing

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -62,7 +62,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         
         {/* Page Content */}
         <main className={cn('flex-1 overflow-auto bg-gradient-to-br from-background to-muted/20', paddingClasses)}>
-          <div className="container mx-auto p-6 max-w-7xl">
+          <div className="mx-auto p-6 pb-12 max-w-screen-2xl">
             {children}
           </div>
         </main>

--- a/src/pages/PremiumDashboard.tsx
+++ b/src/pages/PremiumDashboard.tsx
@@ -120,7 +120,7 @@ export default function PremiumDashboard() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50 dark:from-slate-950 dark:via-blue-950/30 dark:to-indigo-950">
-      <div className="container mx-auto p-6 space-y-8">
+      <div className="container mx-auto p-6 space-y-8 pb-16">
         {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: -20 }}

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -120,7 +120,7 @@ export default function AdminDashboard() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50 dark:from-slate-950 dark:via-blue-950/30 dark:to-indigo-950">
-      <div className="container mx-auto p-6 space-y-8">
+      <div className="container mx-auto p-6 space-y-8 pb-16">
         {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: -20 }}


### PR DESCRIPTION
## Summary
- expand main layout width so dashboard can fill more space
- add bottom padding to both dashboards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856a6d585fc8330af3373d876674f6c