### PR TITLE
Add routing scaffolds for new dashboard sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,9 +18,17 @@ import Roles from "./pages/Roles";
 import Settings from "./pages/Settings";
 import Bookings from "./pages/Bookings";
 import Activities from "./pages/Activities";
-import Swimming from "./pages/Swimming";  
+import Swimming from "./pages/Swimming";
 import Fields from "./pages/Fields";
 import Clients from "./pages/Clients";
+import SwimmingSchools from "./pages/swimming/Schools";
+import SwimmingPrivate from "./pages/swimming/Private";
+import SwimmingFreeTime from "./pages/swimming/FreeTime";
+import FootballAcademy from "./pages/football/Academy";
+import FootballSchools from "./pages/football/Schools";
+import FootballFields from "./pages/football/Fields";
+import CollectionsPage from "./pages/finance/Collections";
+import PricingPage from "./pages/finance/Pricing";
 import NotFound from "./pages/NotFound";
 import { LanguageProvider } from '@/context/LanguageContext';
 
@@ -80,6 +88,40 @@ const App = () => (
                   <Layout><Fields /></Layout>
                 </AuthLayout>
               } />
+
+              {/* Swimming Sub Routes */}
+              <Route path="/swimming/schools" element={
+                <AuthLayout>
+                  <Layout><SwimmingSchools /></Layout>
+                </AuthLayout>
+              } />
+              <Route path="/swimming/private" element={
+                <AuthLayout>
+                  <Layout><SwimmingPrivate /></Layout>
+                </AuthLayout>
+              } />
+              <Route path="/swimming/free-time" element={
+                <AuthLayout>
+                  <Layout><SwimmingFreeTime /></Layout>
+                </AuthLayout>
+              } />
+
+              {/* Football Section */}
+              <Route path="/football/academy" element={
+                <AuthLayout>
+                  <Layout><FootballAcademy /></Layout>
+                </AuthLayout>
+              } />
+              <Route path="/football/schools" element={
+                <AuthLayout>
+                  <Layout><FootballSchools /></Layout>
+                </AuthLayout>
+              } />
+              <Route path="/football/fields" element={
+                <AuthLayout>
+                  <Layout><FootballFields /></Layout>
+                </AuthLayout>
+              } />
               
               <Route path="/clients" element={
                 <AuthLayout requiredRole="manager">
@@ -132,6 +174,18 @@ const App = () => (
               <Route path="/payments" element={
                 <AuthLayout>
                   <Layout><Dashboard /></Layout>
+                </AuthLayout>
+              } />
+
+              {/* Financial Affairs */}
+              <Route path="/finance/collections" element={
+                <AuthLayout>
+                  <Layout><CollectionsPage /></Layout>
+                </AuthLayout>
+              } />
+              <Route path="/finance/pricing" element={
+                <AuthLayout>
+                  <Layout><PricingPage /></Layout>
                 </AuthLayout>
               } />
               

--- a/src/components/layout/modernSidebar/sidebarConfig.ts
+++ b/src/components/layout/modernSidebar/sidebarConfig.ts
@@ -1,134 +1,69 @@
 
 import {
   LayoutDashboard,
-  Calendar,
   Users,
   Shield,
-  BarChart3,
   Settings,
-  Building,
-  Waves,
   MapPin,
   CreditCard,
   User,
-  UserCheck
+  UserCheck,
+  School,
+  Clock,
+  GraduationCap,
+  DollarSign
 } from 'lucide-react';
 
 export const sidebarConfig = {
   groups: [
     {
-      label: 'navigation.main',
+      label: 'لوحة التحكم',
       items: [
         {
           href: '/dashboard',
           label: 'لوحة التحكم',
           icon: LayoutDashboard,
           badge: null
-        },
-        {
-          href: '/admin/dashboard',
-          label: 'لوحة التحكم الرئيسية',
-          icon: LayoutDashboard,
-          badge: 'admin'
         }
       ]
     },
     {
-      label: 'إدارة المرافق',
+      label: 'السباحة',
       items: [
-        {
-          href: '/admin/facilities',
-          label: 'إدارة المرافق',
-          icon: Building,
-          badge: 'admin'
-        },
-        {
-          href: '/activities/swimming',
-          label: 'أنشطة السباحة',
-          icon: Waves,
-          badge: null
-        },
-        {
-          href: '/activities/fields',
-          label: 'أنشطة الملاعب',
-          icon: MapPin,
-          badge: null
-        }
+        { href: '/swimming/schools', label: 'المدارس', icon: School, badge: null },
+        { href: '/swimming/private', label: 'البرايفيت', icon: Users, badge: null },
+        { href: '/swimming/free-time', label: 'الفترة الحرة', icon: Clock, badge: null }
       ]
     },
     {
-      label: 'إدارة الحجوزات',
+      label: 'كرة القدم',
       items: [
-        {
-          href: '/bookings',
-          label: 'الحجوزات',
-          icon: Calendar,
-          badge: null
-        },
-        {
-          href: '/admin/bookings',
-          label: 'إدارة الحجوزات',
-          icon: Calendar,
-          badge: 'admin'
-        },
-        {
-          href: '/payments',
-          label: 'المدفوعات',
-          icon: CreditCard,
-          badge: null
-        }
+        { href: '/football/academy', label: 'الأكاديمية', icon: GraduationCap, badge: null },
+        { href: '/football/schools', label: 'المدارس', icon: School, badge: null },
+        { href: '/football/fields', label: 'إدارة الملاعب', icon: MapPin, badge: null }
       ]
     },
     {
-      label: 'إدارة المستخدمين',
+      label: 'العملاء والأفراد',
       items: [
-        {
-          href: '/clients',
-          label: 'العملاء',
-          icon: Users,
-          badge: null
-        },
-        {
-          href: '/users',
-          label: 'المستخدمين',
-          icon: User,
-          badge: null
-        },
-        {
-          href: '/players',
-          label: 'اللاعبين',
-          icon: User,
-          badge: 'new'
-        },
-        {
-          href: '/coaches',
-          label: 'المدربين',
-          icon: UserCheck,
-          badge: 'new'
-        }
+        { href: '/clients', label: 'العملاء', icon: Users, badge: null },
+        { href: '/coaches', label: 'المدربين', icon: UserCheck, badge: null },
+        { href: '/players', label: 'اللاعبين', icon: User, badge: null }
       ]
     },
     {
-      label: 'الإدارة والإعدادات',
+      label: 'التطبيق',
       items: [
-        {
-          href: '/roles',
-          label: 'الأدوار والصلاحيات',
-          icon: Shield,
-          badge: 'admin'
-        },
-        {
-          href: '/reports',
-          label: 'التقارير',
-          icon: BarChart3,
-          badge: null
-        },
-        {
-          href: '/settings',
-          label: 'الإعدادات',
-          icon: Settings,
-          badge: null
-        }
+        { href: '/settings', label: 'الإعدادات', icon: Settings, badge: null },
+        { href: '/roles', label: 'الصلاحيات والأدوار', icon: Shield, badge: null },
+        { href: '/users', label: 'المستخدمين', icon: User, badge: null }
+      ]
+    },
+    {
+      label: 'الشؤون المالية',
+      items: [
+        { href: '/finance/collections', label: 'التحصيل', icon: CreditCard, badge: null },
+        { href: '/finance/pricing', label: 'تسعير الخدمات', icon: DollarSign, badge: null }
       ]
     }
   ]

--- a/src/pages/finance/Collections.tsx
+++ b/src/pages/finance/Collections.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const CollectionsPage: React.FC = () => (
+  <div className="space-y-6 p-6">
+    <h1 className="text-2xl font-bold">التحصيل</h1>
+    <p>محتوى تجريبي لصفحة التحصيل.</p>
+  </div>
+)
+
+export default CollectionsPage

--- a/src/pages/finance/Pricing.tsx
+++ b/src/pages/finance/Pricing.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const PricingPage: React.FC = () => (
+  <div className="space-y-6 p-6">
+    <h1 className="text-2xl font-bold">تسعير الخدمات</h1>
+    <p>محتوى تجريبي لصفحة التسعير.</p>
+  </div>
+)
+
+export default PricingPage

--- a/src/pages/football/Academy.tsx
+++ b/src/pages/football/Academy.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const FootballAcademy: React.FC = () => (
+  <div className="space-y-6 p-6">
+    <h1 className="text-2xl font-bold">أكاديمية كرة القدم</h1>
+    <p>محتوى تجريبي للأكاديمية.</p>
+  </div>
+)
+
+export default FootballAcademy

--- a/src/pages/football/Fields.tsx
+++ b/src/pages/football/Fields.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const FootballFields: React.FC = () => (
+  <div className="space-y-6 p-6">
+    <h1 className="text-2xl font-bold">إدارة الملاعب</h1>
+    <p>محتوى تجريبي للملاعب.</p>
+  </div>
+)
+
+export default FootballFields

--- a/src/pages/football/Schools.tsx
+++ b/src/pages/football/Schools.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const FootballSchools: React.FC = () => (
+  <div className="space-y-6 p-6">
+    <h1 className="text-2xl font-bold">مدارس كرة القدم</h1>
+    <p>محتوى تجريبي للمدارس.</p>
+  </div>
+)
+
+export default FootballSchools

--- a/src/pages/swimming/FreeTime.tsx
+++ b/src/pages/swimming/FreeTime.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import FreeTimeBookings from './FreeTimeBookings'
+
+const SwimmingFreeTime: React.FC = () => (
+  <div className="space-y-6">
+    <h1 className="text-2xl font-bold">الفترة الحرة</h1>
+    <FreeTimeBookings />
+  </div>
+)
+
+export default SwimmingFreeTime

--- a/src/pages/swimming/Private.tsx
+++ b/src/pages/swimming/Private.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import PrivateBookings from './PrivateBookings'
+
+const SwimmingPrivate: React.FC = () => (
+  <div className="space-y-6">
+    <h1 className="text-2xl font-bold">حجوزات البرايفيت</h1>
+    <PrivateBookings />
+  </div>
+)
+
+export default SwimmingPrivate

--- a/src/pages/swimming/Schools.tsx
+++ b/src/pages/swimming/Schools.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import SchoolsBookings from './SchoolsBookings'
+
+const SwimmingSchools: React.FC = () => (
+  <div className="space-y-6">
+    <h1 className="text-2xl font-bold">مدارس السباحة</h1>
+    <SchoolsBookings />
+  </div>
+)
+
+export default SwimmingSchools


### PR DESCRIPTION
## Summary
- scaffold basic pages for swimming, football, and finance sections
- add new routes for these pages
- update sidebar configuration with the new section links

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6856bd7337688330a68fc517450f9be1