### PR TITLE
Configure GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,8 @@ export default defineConfig(({ mode }) => ({
     port: 7000,
   },
 
-  // تحقق من إذا كانت البيئة هي GitHub Pages (غالبًا ما يكون `production`)
-  base: process.env.NODE_ENV === 'gh-pages' ? '/chico-wahtsapp/' : '/',
+  // Set base path depending on build mode so GitHub Pages serves assets correctly
+  base: mode === 'gh-pages' ? '/chico-wahtsapp/' : '/',
 
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- set base path dynamically based on build `mode` for Vite

## Testing
- `yarn build-gh-pages` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685dd6ca9e5883308459f3b3e6cfae85