### PR TITLE
Improve theming and sidebar UX

### DIFF
--- a/src/components/layout/SidebarRail.tsx
+++ b/src/components/layout/SidebarRail.tsx
@@ -40,6 +40,18 @@ export const SidebarRail: React.FC = () => {
     sidebarOpen ? 'translate-x-0' : isRTL ? 'translate-x-full lg:translate-x-0' : '-translate-x-full lg:translate-x-0'
   );
 
+  const handleMouseEnter = () => {
+    if (!sidebarOpen && window.innerWidth >= 1024) {
+      setSidebarOpen(true);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (sidebarOpen && window.innerWidth >= 1024) {
+      setSidebarOpen(false);
+    }
+  };
+
   return (
     <>
       {sidebarOpen && (
@@ -52,12 +64,19 @@ export const SidebarRail: React.FC = () => {
         />
       )}
 
-      <motion.aside ref={ref} className={sidebarClasses} role="navigation" aria-label={t('navigation.main')}>
+      <motion.aside
+        ref={ref}
+        className={sidebarClasses}
+        role="navigation"
+        aria-label={t('navigation.main')}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
         <SidebarHeader />
         <div className="flex-1 overflow-y-auto px-3 py-4">
           {sidebarConfig.groups.map((group) => (
             <SidebarNavGroup
-              key={group.label}
+              key={group.id}
               group={group}
               isCollapsed={!sidebarOpen}
               currentPath={location.pathname}

--- a/src/components/layout/modernSidebar/ModernSidebar.tsx
+++ b/src/components/layout/modernSidebar/ModernSidebar.tsx
@@ -82,7 +82,7 @@ export function ModernSidebar() {
           <nav className="space-y-6">
             {sidebarConfig.groups.map((group, index) => (
               <SidebarNavGroup
-                key={group.label}
+                key={group.id}
                 group={group}
                 isCollapsed={!sidebarOpen}
                 currentPath={location.pathname}

--- a/src/components/layout/modernSidebar/SidebarNavGroup.tsx
+++ b/src/components/layout/modernSidebar/SidebarNavGroup.tsx
@@ -4,6 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { SidebarNavItem } from './SidebarNavItem';
 import { SidebarGroup } from './types';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from '@/components/ui/accordion';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface SidebarNavGroupProps {
   group: SidebarGroup;
@@ -15,36 +22,49 @@ interface SidebarNavGroupProps {
 export function SidebarNavGroup({ group, isCollapsed, currentPath, isRTL }: SidebarNavGroupProps) {
   const { t } = useTranslation();
 
-  return (
-    <div>
-      {/* Group Label */}
-      {!isCollapsed && (
-        <h3 className={cn(
-          'mb-3 px-3 text-xs font-semibold text-sidebar-foreground/60 uppercase tracking-wider',
-          isRTL ? 'text-right' : 'text-left'
-        )}>
-          {t(group.label)}
-        </h3>
-      )}
-
-      {/* Separator for collapsed state */}
-      {isCollapsed && (
-        <div className="mx-3 mb-4 border-t border-sidebar-border opacity-30" />
-      )}
-
-      {/* Navigation Items */}
-      <ul className="space-y-1" role="list">
-        {group.items.map((item) => (
-          <li key={item.href}>
-            <SidebarNavItem
-              item={item}
-              isCollapsed={isCollapsed}
-              isActive={currentPath === item.href || currentPath.startsWith(item.href + '/')}
-              isRTL={isRTL}
-            />
-          </li>
-        ))}
-      </ul>
+  const header = (
+    <div className="flex items-center gap-3 px-3 py-2 font-semibold">
+      {group.icon && <group.icon className="h-4 w-4" />}
+      {!isCollapsed && <span className="text-xs uppercase text-sidebar-foreground/60">{t(group.label)}</span>}
     </div>
+  );
+
+  return (
+    <Accordion type="multiple" defaultValue={[group.id]} className="mb-2">
+      <AccordionItem value={group.id} className="border-none">
+        {isCollapsed ? (
+          <TooltipProvider>
+            <Tooltip delayDuration={100}>
+              <TooltipTrigger asChild>
+                <AccordionTrigger className="p-0 hover:no-underline focus:no-underline">
+                  {header}
+                </AccordionTrigger>
+              </TooltipTrigger>
+              <TooltipContent side={isRTL ? 'left' : 'right'}>
+                {t(group.label)}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <AccordionTrigger className="p-0 hover:no-underline focus:no-underline">
+            {header}
+          </AccordionTrigger>
+        )}
+        <AccordionContent className="mt-1 space-y-1">
+          <ul className="space-y-1" role="list">
+            {group.items.map((item) => (
+              <li key={item.href}>
+                <SidebarNavItem
+                  item={item}
+                  isCollapsed={isCollapsed}
+                  isActive={currentPath === item.href || currentPath.startsWith(item.href + '/')}
+                  isRTL={isRTL}
+                />
+              </li>
+            ))}
+          </ul>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   );
 }

--- a/src/components/layout/modernSidebar/sidebarConfig.ts
+++ b/src/components/layout/modernSidebar/sidebarConfig.ts
@@ -13,7 +13,9 @@ import {
   GraduationCap,
   DollarSign,
   Waves,
-  Calculator
+  Calculator,
+  Activity,
+  FileBarChart
 } from 'lucide-react';
 
 export const sidebarConfig = {
@@ -21,6 +23,7 @@ export const sidebarConfig = {
     {
       id: 'dashboard',
       label: 'pages.dashboard',
+      icon: LayoutDashboard,
       items: [
         {
           id: 'main-dashboard',
@@ -32,89 +35,37 @@ export const sidebarConfig = {
       ]
     },
     {
-      id: 'swimming',
-      label: 'pages.swimming',
+      id: 'activities',
+      label: 'pages.activities',
+      icon: Activity,
       items: [
-        { 
-          id: 'swimming-overview',
-          label: 'sidebar.overview', 
-          icon: Waves, 
+        {
+          id: 'swimming',
+          label: 'pages.swimming',
+          icon: Waves,
           href: '/swimming',
-          badge: null 
+          badge: null
         },
-        { 
-          id: 'swimming-schools',
-          label: 'sidebar.schools',
-          icon: School, 
-          href: '/swimming/schools',
-          badge: null 
-        },
-        { 
-          id: 'swimming-private',
-          label: 'sidebar.private',
-          icon: Users, 
-          href: '/swimming/private',
-          badge: null 
-        },
-        { 
-          id: 'swimming-free-time',
-          label: 'sidebar.free_time',
-          icon: Clock, 
-          href: '/swimming/free-time',
-          badge: null 
-        }
-      ]
-    },
-    {
-      id: 'football',
-      label: 'pages.football',
-      items: [
-        { 
-          id: 'football-overview',
-          label: 'sidebar.overview',
-          icon: GraduationCap, 
+        {
+          id: 'football',
+          label: 'pages.football',
+          icon: GraduationCap,
           href: '/football',
-          badge: null 
+          badge: null
         },
-        { 
-          id: 'football-academy',
-          label: 'sidebar.academy',
-          icon: GraduationCap, 
-          href: '/football/academy',
-          badge: null 
-        },
-        { 
-          id: 'football-schools',
-          label: 'sidebar.schools',
-          icon: School, 
-          href: '/football/schools',
-          badge: null 
-        },
-        { 
-          id: 'football-fields',
-          label: 'sidebar.manage_fields',
-          icon: MapPin, 
-          href: '/football/fields',
-          badge: null 
-        }
-      ]
-    },
-    {
-      id: 'fields',
-      label: 'pages.fields',
-      items: [
-        { 
-          id: 'fields-overview',
-          label: 'sidebar.overview',
-          icon: MapPin, 
+        {
+          id: 'fields',
+          label: 'pages.fields',
+          icon: MapPin,
           href: '/fields',
-          badge: null 
+          badge: null
         }
       ]
     },
     {
       id: 'people',
       label: 'sidebar.people',
+      icon: Users,
       items: [
         { 
           id: 'clients',
@@ -142,6 +93,7 @@ export const sidebarConfig = {
     {
       id: 'finance',
       label: 'sidebar.finance',
+      icon: CreditCard,
       items: [
         { 
           id: 'accounting',
@@ -167,29 +119,37 @@ export const sidebarConfig = {
       ]
     },
     {
-      id: 'system',
-      label: 'sidebar.system',
+      id: 'administration',
+      label: 'sidebar.administration',
+      icon: Shield,
       items: [
-        { 
+        {
           id: 'settings',
           label: 'pages.settings',
-          icon: Settings, 
+          icon: Settings,
           href: '/settings',
-          badge: null 
+          badge: null
         },
-        { 
+        {
           id: 'roles',
           label: 'pages.roles',
-          icon: Shield, 
+          icon: Shield,
           href: '/roles',
-          badge: null 
+          badge: null
         },
-        { 
+        {
           id: 'users',
           label: 'pages.users',
-          icon: User, 
+          icon: User,
           href: '/users',
-          badge: null 
+          badge: null
+        },
+        {
+          id: 'reports',
+          label: 'pages.reports',
+          icon: FileBarChart,
+          href: '/reports',
+          badge: null
         }
       ]
     }

--- a/src/components/layout/modernSidebar/types.ts
+++ b/src/components/layout/modernSidebar/types.ts
@@ -9,7 +9,9 @@ export interface SidebarItem {
 }
 
 export interface SidebarGroup {
+  id: string;
   label: string;
+  icon?: LucideIcon;
   items: SidebarItem[];
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Amiri:wght@400;700&family=Cairo:wght@400;500;600;700&display=swap');
+@import "./styles/tokens.css";
 
 @tailwind base;
 @tailwind components;
@@ -9,23 +10,22 @@
 /* CSS Custom Properties for theming */
 @layer base {
   :root {
-    /* Enhanced color palette for better accessibility */
+    /* Base palette */
     --color-primary: 224 71% 44%;
     --color-primary-foreground: 210 40% 98%;
     --color-secondary: 271 81% 56%;
     --color-secondary-foreground: 210 40% 98%;
     --color-accent: 142 76% 36%;
     --color-accent-foreground: 355 7% 97%;
-    
-    /* Improved background colors */
-    --color-bg: 0 0% 100%;
-    --color-surface: 210 40% 98%;
-    --color-card: 0 0% 100%;
-    
-    /* Enhanced text colors for better contrast */
-    --color-text: 222 84% 5%;
-    --color-text-muted: 215 20% 65%;
-    --color-text-subtle: 215 16% 47%;
+
+    /* Map custom design tokens */
+    --color-bg: var(--color-bg-default);
+    --color-surface: var(--color-bg-surface);
+    --color-card: var(--color-bg-card);
+
+    --color-text: var(--color-text-primary);
+    --color-text-muted: var(--color-text-muted);
+    --color-text-subtle: var(--color-text-secondary);
 
     /* Status colors */
     --color-success: 142 71% 45%;
@@ -38,13 +38,13 @@
     --color-input: 214 32% 91%;
     
     /* Sidebar specific colors */
-    --sidebar-background: 210 40% 98%;
-    --sidebar-foreground: 222 47% 11%;
-    --sidebar-primary: 224 71% 44%;
-    --sidebar-primary-foreground: 210 40% 98%;
-    --sidebar-accent: 210 40% 94%;
-    --sidebar-accent-foreground: 222 47% 11%;
-    --sidebar-border: 214 32% 91%;
+    --sidebar-background: var(--color-sidebar-bg);
+    --sidebar-foreground: var(--color-sidebar-foreground);
+    --sidebar-primary: var(--color-sidebar-primary);
+    --sidebar-primary-foreground: var(--color-sidebar-primary-foreground);
+    --sidebar-accent: var(--color-sidebar-accent);
+    --sidebar-accent-foreground: var(--color-sidebar-accent-foreground);
+    --sidebar-border: var(--color-sidebar-border);
 
     /* Map to CSS custom properties */
     --background: var(--color-bg);
@@ -76,24 +76,22 @@
   }
 
   .dark {
-    /* Dark mode color palette with improved contrast */
-    --color-bg: 222 84% 5%;
-    --color-surface: 217 33% 17%;
-    --color-card: 224 71% 4%;
-    
-    /* Enhanced dark mode text colors */
-    --color-text: 210 40% 98%;
-    --color-text-muted: 215 20% 65%;
-    --color-text-subtle: 217 32% 83%;
+    /* Dark mode palette */
+    --color-bg: var(--color-bg-default);
+    --color-surface: var(--color-bg-surface);
+    --color-card: var(--color-bg-card);
 
-    /* Dark mode specific colors */
-    --sidebar-background: 224 71% 4%;
-    --sidebar-foreground: 210 40% 98%;
-    --sidebar-primary: 217 91% 60%;
-    --sidebar-primary-foreground: 222 84% 5%;
-    --sidebar-accent: 217 33% 17%;
-    --sidebar-accent-foreground: 210 40% 98%;
-    --sidebar-border: 217 33% 17%;
+    --color-text: var(--color-text-primary);
+    --color-text-muted: var(--color-text-muted);
+    --color-text-subtle: var(--color-text-secondary);
+
+    --sidebar-background: var(--color-sidebar-bg);
+    --sidebar-foreground: var(--color-sidebar-foreground);
+    --sidebar-primary: var(--color-sidebar-primary);
+    --sidebar-primary-foreground: var(--color-sidebar-primary-foreground);
+    --sidebar-accent: var(--color-sidebar-accent);
+    --sidebar-accent-foreground: var(--color-sidebar-accent-foreground);
+    --sidebar-border: var(--color-sidebar-border);
 
     /* Update mappings for dark mode */
     --background: var(--color-bg);
@@ -102,8 +100,8 @@
     --card-foreground: var(--color-text);
     --popover: var(--color-card);
     --popover-foreground: var(--color-text);
-    --border: 217 33% 17%;
-    --input: 217 33% 17%;
+    --border: var(--color-border);
+    --input: var(--color-input);
     --muted: var(--color-text-muted);
     --muted-foreground: var(--color-text-subtle);
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,51 @@
+@layer base {
+  :root {
+    /* Core colors */
+    --color-bg-default: 0 0% 100%;
+    --color-bg-surface: 210 40% 98%;
+    --color-bg-card: 0 0% 100%;
+
+    --color-text-primary: 222 84% 5%;
+    --color-text-muted: 215 20% 65%;
+    --color-text-secondary: 215 16% 47%;
+
+    --color-primary: 224 71% 44%;
+    --color-primary-foreground: 210 40% 98%;
+    --color-secondary: 271 81% 56%;
+    --color-secondary-foreground: 210 40% 98%;
+    --color-accent: 142 76% 36%;
+    --color-accent-foreground: 355 7% 97%;
+
+    --color-border: 214 32% 91%;
+    --color-input: 214 32% 91%;
+
+    --color-sidebar-bg: 210 40% 98%;
+    --color-sidebar-foreground: 222 47% 11%;
+    --color-sidebar-primary: 224 71% 44%;
+    --color-sidebar-primary-foreground: 210 40% 98%;
+    --color-sidebar-accent: 210 40% 94%;
+    --color-sidebar-accent-foreground: 222 47% 11%;
+    --color-sidebar-border: 214 32% 91%;
+  }
+
+  .dark {
+    --color-bg-default: 222 84% 5%;
+    --color-bg-surface: 217 33% 17%;
+    --color-bg-card: 224 71% 4%;
+
+    --color-text-primary: 210 40% 98%;
+    --color-text-muted: 215 20% 65%;
+    --color-text-secondary: 217 32% 83%;
+
+    --color-border: 217 33% 17%;
+    --color-input: 217 33% 17%;
+
+    --color-sidebar-bg: 224 71% 4%;
+    --color-sidebar-foreground: 210 40% 98%;
+    --color-sidebar-primary: 217 91% 60%;
+    --color-sidebar-primary-foreground: 222 84% 5%;
+    --color-sidebar-accent: 217 33% 17%;
+    --color-sidebar-accent-foreground: 210 40% 98%;
+    --color-sidebar-border: 217 33% 17%;
+  }
+}

--- a/src/translations/ar.json
+++ b/src/translations/ar.json
@@ -125,6 +125,6 @@
     "manage_fields": "إدارة الملاعب",
     "people": "العملاء والأفراد",
     "finance": "الشؤون المالية",
-    "system": "التطبيق"
+    "administration": "الإدارة"
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -125,6 +125,6 @@
     "manage_fields": "Manage Fields",
     "people": "People",
     "finance": "Finance",
-    "system": "System"
+    "administration": "Administration"
   }
 }


### PR DESCRIPTION
## Summary
- add global design tokens
- map CSS variables to tokens for light and dark mode
- redesign sidebar config with grouped sections and icons
- add collapsible sidebar groups with tooltips
- enable hover expansion on large screens
- update translations for new labels

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685f17b748fc8330ab79f4fdeeeb3a10